### PR TITLE
juniper-8: ARM64 CozyStack image patches + skill + docs

### DIFF
--- a/.github/skills/cozystack-patch-workflow/SKILL.md
+++ b/.github/skills/cozystack-patch-workflow/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: cozystack-patch-workflow
+description: 'Workflow skill for creating, validating, and applying patches against an upstream CozyStack source tree. Use when: creating new patches for CozyStack ARM64 image builds; editing Dockerfiles or Makefiles in a cloned CozyStack worktree; running git diff to produce numbered patch files; validating patches with git apply --check; adding patches to the build workflow matrix; reviewing or updating existing patches in patches/. DO NOT use for general Kubernetes troubleshooting or Talos node configuration.'
+argument-hint: 'Describe the change you want to patch (e.g. "set default PLATFORM to linux/arm64 in common-envs.mk")'
+---
+
+# CozyStack Patch Workflow
+
+## Overview
+
+This skill produces reproducible `.patch` files against a pinned upstream CozyStack
+release. Patches are always generated from actual edits to a cloned worktree — never
+hand-crafted.
+
+## Invariants
+
+- **No hand-crafted patches.** Every patch is produced via `git diff` on a real edit.
+- Patches live in `patches/` with the naming scheme `<NN>-<slug>.patch`.
+- Always validate with `git apply --check` on a separate clean clone before committing.
+- The upstream ref to patch against is `v1.3.3` unless a newer pinned version is active.
+
+## Workflow
+
+### 1. Prepare a patch worktree
+
+```bash
+UPSTREAM_REF=v1.3.3
+WORKDIR=/tmp/cozy-patch-work
+git clone --depth 1 --branch "$UPSTREAM_REF" \
+  https://github.com/cozystack/cozystack "$WORKDIR"
+```
+
+### 2. Make the targeted edit
+
+Edit the file(s) inside `$WORKDIR`. Keep changes minimal and focused. Document *why*
+in the commit message or a comment if the diff doesn't make it obvious.
+
+Common edit targets for ARM64 work:
+- `hack/common-envs.mk` — default `PLATFORM`
+- `packages/system/<pkg>/Makefile` — platform flags, skopeo retag logic
+- `packages/system/<pkg>/images/<name>/Dockerfile` — base image arch
+
+### 3. Produce the patch
+
+```bash
+cd "$WORKDIR"
+NEXT_NUM=$(ls /path/to/repo/patches/*.patch 2>/dev/null | wc -l | tr -d ' ')
+PADDED=$(printf "%02d" $((NEXT_NUM + 1)))
+git diff > /path/to/repo/patches/${PADDED}-<slug>.patch
+```
+
+### 4. Validate on a clean clone
+
+```bash
+VALIDATE_DIR=/tmp/cozy-validate-$$
+git clone --depth 1 --branch "$UPSTREAM_REF" \
+  https://github.com/cozystack/cozystack "$VALIDATE_DIR"
+git -C "$VALIDATE_DIR" apply --check \
+  /path/to/repo/patches/${PADDED}-<slug>.patch
+echo "Patch check exit code: $?"
+```
+
+A zero exit code means the patch applies cleanly.
+
+### 5. Register the patch in the build workflow
+
+In `.github/workflows/build-talos-images.yml` (or the relevant workflow), find the
+`Apply patches` step and add the new patch:
+
+```yaml
+- name: Apply patches
+  run: |
+    git apply patches/01-arm64-spin-tailscale.patch
+    git apply patches/02-makefile-architecture-variables.patch
+    git apply patches/03-arm64-spin-only.patch
+    git apply patches/${PADDED}-<slug>.patch   # ← add here
+```
+
+### 6. Commit
+
+```bash
+git add patches/${PADDED}-<slug>.patch
+git add .github/workflows/build-talos-images.yml   # if workflow changed
+git commit -m "patches: add ${PADDED}-<slug> — <one line description>"
+```
+
+## Patch Naming Conventions
+
+| Number | Purpose |
+|--------|---------|
+| 01–03 | Talos ARM64 profile + extension variants (existing) |
+| 04 | `hack/common-envs.mk` — default PLATFORM=linux/arm64 |
+| 05 | `packages/system/dashboard/Makefile` — add arm64 to hardcoded platform |
+| 06 | `packages/system/kubeovn/Makefile` — retag full manifest list |
+| 07+ | Future package-specific ARM64 fixes |
+
+## Troubleshooting
+
+**`git apply --check` fails with "patch does not apply"**
+The upstream file changed between the patch source and the validation clone. Re-diff
+against the exact same `UPSTREAM_REF` tag, or rebase the edit onto the newer ref.
+
+**Makefile variable not being picked up**
+Check `hack/common-envs.mk` include order. Variables set before the `include` line
+will not be overridden by the `?=` default.
+
+**Skopeo retag copies only amd64 manifest**
+Use `skopeo copy --all` (or `crane copy`) to copy the full manifest list. Omitting
+`--all` causes skopeo to resolve the manifest to the host arch and copy only that
+single-arch manifest.
+
+## References
+
+- Upstream CozyStack: https://github.com/cozystack/cozystack
+- Build workflows: [.github/workflows/](.github/workflows/)
+- Existing patches: [patches/](patches/)
+- JUNIPER-8 plan: [docs/JUNIPER-8-ARM64-COZYSTACK-IMAGES.md](docs/JUNIPER-8-ARM64-COZYSTACK-IMAGES.md)

--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -133,6 +133,13 @@ jobs:
           EXTENSION_VARIANT="${{ matrix.extension_variant }}"
           echo "Building with extension variant: $EXTENSION_VARIANT"
           
+          # Always apply: default PLATFORM to linux/arm64 in common-envs.mk
+          git apply ../patches/04-arm64-default-platform.patch || {
+            echo "Failed to apply 04-arm64-default-platform.patch"
+            git status
+            exit 1
+          }
+
           if [ "$EXTENSION_VARIANT" = "spin-only" ]; then
             echo "Applying ARM64+Spin-only patches..."
             git apply ../patches/03-arm64-spin-only.patch || {

--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Apply spin-only ARM64 patches
         run: |
           cd cozystack-upstream
+          git apply ../patches/04-arm64-default-platform.patch
           git apply ../patches/03-arm64-spin-only.patch
           git apply ../patches/02-makefile-architecture-variables.patch
           chmod +x packages/core/talos/hack/gen-profiles.sh

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > **Validating ARM64 Kubernetes in the cloud before committing to bare-metal**  
 > *Smart validation strategy: Test first, buy hardware second*
 
-[![CozySummit Virtual 2025](https://img.shields.io/badge/CozySummit-Dec%204%2C%202025-blue)](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2025/)
+[![CozySummit Virtual 2026](https://img.shields.io/badge/CozySummit-May%2026%2C%202026-blue)](https://community2.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2026/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 [![Built with TDG](https://img.shields.io/badge/built%20with-TDG-purple)](https://chanwit.medium.com/i-was-wrong-about-test-driven-generation-and-i-couldnt-be-happier-9942b6f09502)
 
@@ -19,7 +19,7 @@ Transform a **128°F office space heater** (aka home lab) into a **cloud-validat
 - ✅ Demonstrates WebAssembly on ARM64 in production-like conditions
 - ✅ Proves when cloud makes sense vs. efficient home lab hardware
 
-**Target**: Live demo at [CozySummit Virtual 2025](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2025/) on **December 3, 2025**
+**Target**: Live demo at [CozySummit Virtual 2026](https://community2.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2026/) on **May 26, 2026**
 
 ### 🧪 TDG Test Status (Updated: November 19, 2025)
 
@@ -403,14 +403,14 @@ This project demonstrates:
 
 ## 🏆 Success Metrics
 
-### Demo Day (December 3)
+### Event Day (May 26)
 - [ ] Tests 1-6 passing (Network → Demo workload)
 - [ ] Live netboot < 5 minutes
 - [ ] SpinKube demo runs on ARM64
 - [ ] Cost stays under $0.10/month
 - [ ] Audience can replicate in their own AWS account
 
-### Post-Demo
+### Post-Event
 - [ ] Home lab transitions to Raspberry Pi CM3 modules
 - [ ] Office temperature drops 15°F
 - [ ] Power bill decreases measurably

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ baseurl: "/cozystack-moon-and-back"
 url: "https://urmanac.github.io"
 
 # Site settings
-author: "CozySummit Virtual 2025"
+author: "CozySummit Virtual 2026"
 email: "kingdon@urmanac.com"
 
 # Navigation
@@ -44,4 +44,4 @@ repository: urmanac/cozystack-moon-and-back
 # Social links
 social_links:
   - https://github.com/urmanac/cozystack-moon-and-back
-  - https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2025/
+  - https://community2.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2026/

--- a/docs/ION-7-ORBITAL-REBOOT.md
+++ b/docs/ION-7-ORBITAL-REBOOT.md
@@ -69,3 +69,81 @@ Validated against clean upstream v1.3.3 worktree:
 1. The old 0.38 assumptions no longer represent upstream build topology.
 2. Without this migration, ARM64 patching fails before any build starts.
 3. With these updates, the repo again aligns with its core purpose: producing publishable ARM64 CozyStack images for real hardware clusters.
+
+---
+
+## ARM64 Image Audit: In-Tree Built Images (CozyStack v1.3.3)
+
+**Finding date: 2026-05-15**
+
+### Root Cause
+`hack/common-envs.mk` sets `PLATFORM ?=` (empty). On GitHub's amd64 runners, every `docker buildx build $(BUILDX_ARGS)` produces a single-arch amd64 image. CozyStack v1.3.3 ships **zero** multi-arch images.
+
+The one exception — `packages/system/dashboard` — is irrecoverably amd64-only because its three `docker buildx build` invocations hardcode `--platform=linux/amd64`.
+
+### Packages with In-Tree Built Images (all amd64-only)
+
+| Image | Package | Values key to override |
+|---|---|---|
+| `cozystack-operator:<TAG>` | `packages/core/installer` | `.cozystackOperator.image` |
+| `cozystack-controller:<TAG>` | `packages/system/cozystack-controller` | `.cozystackController.image` |
+| `cozystack-api:<TAG>` | `packages/system/cozystack-api` | `.cozystackAPI.image` |
+| `backup-controller:<TAG>` | `packages/system/backup-controller` | `.backupController.image` |
+| `backupstrategy-controller:<TAG>` | `packages/system/backupstrategy-controller` | `.backupStrategyController.image` |
+| `lineage-controller-webhook:<TAG>` | `packages/system/lineage-controller-webhook` | `.lineageControllerWebhook.image` |
+| `platform-migrations:<TAG>` | `packages/core/platform` | `.migrations.image` |
+| `kamaji:<TAG>` | `packages/system/kamaji` | `.kamaji.image.repository` + `.kamaji.image.tag` |
+| `cilium:<appVersion>` | `packages/system/cilium` | `.cilium.image.repository/tag/digest` |
+| `kubeovn-webhook:<TAG>` | `packages/system/kubeovn-webhook` | `.image` |
+| `kubeovn-plunger:<TAG>` | `packages/system/kubeovn-plunger` | `.image` |
+| `matchbox:<TAG>` | `packages/core/talos` | `packages/extra/bootbox/images/matchbox.tag` |
+| `metallb-controller/speaker:<ver>` | `packages/system/metallb` | `.metallb.controller/speaker.image.repository/tag` |
+| `multus-cni:<TAG>` | `packages/system/multus` | Injected via `sed` in templates |
+| `linstor`/`piraeus-server` | `packages/system/linstor` | `.piraeusServer.image.*` |
+| `linstor-csi:<ver>` | `packages/system/linstor` | `.linstorCSI.image.*` |
+| `linstor-gui:<ver>` | `packages/system/linstor-gui` | `.image.*` |
+| `openapi-ui` + 2 others | `packages/system/dashboard` | **amd64 hardcoded — skip** |
+| `grafana-dashboards:<TAG>` | `packages/system/grafana-operator` | `.tag` file |
+
+### kubeovn: amd64-only retag confirmed
+
+```
+ghcr.io/cozystack/cozystack/kubeovn:v1.15.10
+→ manifest.v2+json (single-arch, amd64 only)
+```
+
+Upstream `docker.io/kubeovn/kube-ovn:v1.15.10` is a proper manifest list:
+- `arm64` → `sha256:a64ff020a2f2a89ff2494565941e584029aee19f49d9a1fd631dbfcbdd0efbca`
+- `amd64` → `sha256:8cc2afda38aa9cd400cab1d30f5833ec3839e30acd2d46898f49e8f9510f349a`
+
+CozyStack's `make update` retags only the amd64 manifest to GHCR — it never copies the full manifest list.
+
+### kube-ovn values.yaml pin (the actual breakage)
+
+```yaml
+global:
+  registry:
+    address: ghcr.io/cozystack/cozystack
+  images:
+    kubeovn:
+      repository: kubeovn
+      tag: v1.15.10@sha256:741299cbd0081a786a6b60c460fa3156b3a42a38141c559dd8ac031f50c5504f
+```
+
+The `@sha256:...` digest pins to the amd64 manifest specifically. On arm64 nodes the pod fails with `exec format error`.
+
+### Packages that pull upstream multi-arch (no rebuild needed)
+
+`cert-manager`, `fluxcd`, `metrics-server`, `ingress-nginx`, `coredns`, `cloudnative-pg` (postgres-operator), `external-secrets`, `keycloak`, `piraeus-operator`, `victoria-metrics-operator`, `snapshot-controller`.
+
+### kubevirt: special status
+
+`quay.io/kubevirt/*` — ARM64 support is experimental upstream. Avoid KubeVirt workloads on pure ARM64 nodes for now.
+
+### Plan for JUNIPER-8
+
+1. Clone upstream CozyStack v1.3.3, make `PLATFORM=linux/arm64` changes, run `git diff` to produce new patches (never hand-craft patches).
+2. Build all critical in-tree images for `linux/arm64`, pushing to `ghcr.io/urmanac/cozystack-assets/*`.
+3. The `kubeovn` image specifically: retag the upstream arm64 manifest to our registry rather than retagging a single-arch amd64 manifest.
+4. Override image refs in `talm-chart/` or via `HelmRelease` patches to point at `ghcr.io/urmanac/cozystack-assets/*` ARM64 images.
+5. Delete stale tags, push PR to `docs/arm64-pxe-guide-refresh` → main → tag → CI publishes new bundle.

--- a/docs/JUNIPER-8-ARM64-COZYSTACK-IMAGES.md
+++ b/docs/JUNIPER-8-ARM64-COZYSTACK-IMAGES.md
@@ -1,0 +1,178 @@
+# JUNIPER-8: ARM64 CozyStack Image Rebuild
+
+**Date: 2026-05-15**
+
+## Mission
+
+Build all CozyStack v1.3.3 in-tree images for `linux/arm64` and ship them to
+`ghcr.io/urmanac/cozystack-assets/*`, so that a real ARM64 cluster (CM4 / Turing Pi)
+can run the full CozyStack stack without `exec format error` crashes.
+
+## Context
+
+ION-7 audit found that every image CozyStack builds in-tree is amd64-only. The root
+cause is `hack/common-envs.mk` leaving `PLATFORM ?=` empty, so builds on GitHub's
+amd64 runners always produce single-arch amd64 images.
+
+The `kubeovn` image is additionally broken because the retag step copies only the amd64
+manifest to GHCR, pinning a `@sha256:...` digest that points to the amd64 manifest.
+
+Cilium was already fixed by pinning to `quay.io/cilium/cilium:v1.19.4` (upstream
+multi-arch) in the active HelmRelease.
+
+## Target Registry Layout
+
+All arm64 images ship to `ghcr.io/urmanac/cozystack-assets/cozystack/<name>:<tag>`,
+mirroring the upstream `ghcr.io/cozystack/cozystack/<name>:<tag>` path structure so
+overrides are easy to express as a single registry swap.
+
+## Patch Strategy
+
+**Rule: no hand-crafted patches.** Every patch is produced by:
+1. `git clone --depth 1 --branch v1.3.3 https://github.com/cozystack/cozystack /tmp/cozy-patch-work`
+2. Edit the target file(s) in the worktree.
+3. `git diff > patches/<NN>-<description>.patch`
+4. Verify with `git apply --check patches/<NN>-<description>.patch` on a clean clone.
+
+## Patches Needed
+
+### Patch 04 — `hack/common-envs.mk`: default PLATFORM to linux/arm64
+
+**File:** `hack/common-envs.mk`
+
+Change:
+```makefile
+PLATFORM ?=
+```
+to:
+```makefile
+PLATFORM ?= linux/arm64
+```
+
+This makes `$(BUILDX_ARGS)` inject `--platform=linux/arm64` for every package that
+uses `common-envs.mk`, which covers all custom-built images except `dashboard`.
+
+### Patch 05 — `packages/system/dashboard/Makefile`: add arm64 to hardcoded platform
+
+**File:** `packages/system/dashboard/Makefile`
+
+Change every:
+```makefile
+--platform=linux/amd64 \
+```
+to:
+```makefile
+--platform=linux/amd64,linux/arm64 \
+```
+
+**Note:** dashboard images are UI-only and not required for cluster operation. This
+patch can be deferred if the cross-compile adds build time we can't absorb.
+
+### Patch 06 — `packages/system/kubeovn/Makefile`: retag the full manifest list
+
+**File:** `packages/system/kubeovn/Makefile`
+
+The `make update` step currently runs `skopeo copy` (or equivalent) referencing only the
+amd64 manifest. We need to copy the full manifest list from `docker.io/kubeovn/kube-ovn`
+to our registry, then update `values.yaml` to point at the new location without a
+digest pin.
+
+After the copy:
+```yaml
+global:
+  registry:
+    address: ghcr.io/urmanac/cozystack-assets/cozystack
+  images:
+    kubeovn:
+      repository: kubeovn
+      tag: v1.15.10   # no @sha256 — manifest list selects arch automatically
+```
+
+### Patch 07 — `packages/core/talos/Makefile`: arm64 asset names
+
+Already covered by existing patches 01–03 for the Talos/matchbox images in this repo.
+No additional patch needed here for the CozyStack-side images.
+
+## Build Workflow Changes
+
+The existing `build-talos-images.yml` builds Talos + matchbox + cozystack-operator.
+A new or extended workflow will build the remaining CozyStack packages for arm64:
+
+```
+build-cozystack-arm64-images.yml
+  matrix:
+    package:
+      - packages/system/cilium          # already fixed via upstream pin
+      - packages/system/kubeovn         # retag manifest list
+      - packages/system/metallb
+      - packages/system/kamaji
+      - packages/system/multus
+      - packages/system/kubeovn-webhook
+      - packages/system/kubeovn-plunger
+      - packages/system/cozystack-controller
+      - packages/system/cozystack-api
+      - packages/system/backup-controller
+      - packages/system/backupstrategy-controller
+      - packages/system/lineage-controller-webhook
+      - packages/system/linstor
+      - packages/system/linstor-gui
+  steps:
+    - checkout cozystack v1.3.3
+    - apply patches 04+
+    - for each package: make image REGISTRY=ghcr.io/urmanac/cozystack-assets/cozystack PUSH=true
+```
+
+## Override Mechanism
+
+Rather than modifying the upstream Helm charts, overrides are expressed as
+`HelmRelease` `.spec.values` patches in the `talm-chart/` (or a new `patches/`
+directory):
+
+```yaml
+# Example: kubeovn override
+kube-ovn:
+  global:
+    registry:
+      address: ghcr.io/urmanac/cozystack-assets/cozystack
+    images:
+      kubeovn:
+        repository: kubeovn
+        tag: v1.15.10
+```
+
+This approach keeps the CozyStack Helm chart untouched and localises all ARM64
+adaptations to this repo.
+
+## Execution Order
+
+1. **Patches 04 + 06** (common-envs default platform, kubeovn manifest-list retag) — these have the highest cluster impact.
+2. Produce patch files from cloned worktree via `git diff`.
+3. Validate all patches with `git apply --check` on a fresh v1.3.3 clone.
+4. Wire patches into the build workflow.
+5. Delete stale GHCR tags (`talos:v1.3.3`, `talos:v1.13.2`, `matchbox:talos-v1.13.2-cozy-v1.3.3`).
+6. Push `docs/arm64-pxe-guide-refresh` → PR → merge to main.
+7. Tag `v1.3.3` on new commit → `release-talos-assets.yml` fires.
+8. Inspect published manifests for arm64 presence.
+9. Apply kubeovn HelmRelease override on running cluster, watch init containers recover.
+
+## Agent Skill: cozystack-patch-workflow
+
+After this session's patches are validated, we will build a reusable agent skill
+(`cozystack-patch-workflow`) that codifies:
+- Cloning a specific upstream ref to a temp worktree.
+- Making targeted edits.
+- Producing a numbered patch file via `git diff`.
+- Validating with `git apply --check` on a clean clone.
+- Updating the build workflow matrix with the new patch.
+
+This skill lives alongside the existing skills and can be invoked for any future
+patch work against CozyStack or similar upstream sources.
+
+## Success Criteria
+
+- `crane manifest ghcr.io/urmanac/cozystack-assets/cozystack/kubeovn:v1.15.10`
+  → manifest list with `linux/arm64` entry
+- `crane manifest ghcr.io/urmanac/cozystack-assets/cozystack/cozystack-operator:<tag>`
+  → contains `linux/arm64`
+- kube-ovn init containers reach `Running` on CM4 nodes
+- `cozystack-operator` pod runs on arm64 nodes without `exec format error`

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ title: "CozyStack"
 
 > **Validating ARM64 Kubernetes in the cloud before committing to bare-metal hardware**
 
-[![CozySummit Virtual 2025](https://img.shields.io/badge/CozySummit-Dec%204%2C%202025-blue)](https://community.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2025/)
+[![CozySummit Virtual 2026](https://img.shields.io/badge/CozySummit-May%2026%2C%202026-blue)](https://community2.cncf.io/events/details/cncf-virtual-project-events-hosted-by-cncf-presents-cozysummit-virtual-2026/)
 [![Built with TDG](https://img.shields.io/badge/built%20with-TDG-purple)](docs/ADRs/ADR-002-TDG-METHODOLOGY.html)
 [![GitHub Pages](https://img.shields.io/badge/docs-GitHub%20Pages-green)](https://urmanac.github.io/cozystack-moon-and-back/)
 
@@ -20,7 +20,7 @@ Transform a **128°F office space heater** into an **ARM64-first cloud deploymen
 - ✅ **Talos Linux** with WebAssembly + Tailscale subnet router
 - ✅ **AWS validation** before hardware purchase  
 - ✅ **Budget-conscious**: <$0.10/month baseline, <$15/month testing
-- ✅ **Live demo** at CozySummit Virtual 2025 (December 3)
+- ✅ **Live demo** at CozySummit Virtual 2026 (May 26)
 
 ---
 
@@ -58,9 +58,9 @@ Architectural decisions documented in ADRs:
 
 ## 🚀 Current Status
 
-**⚠️ Pre-Demo Development Phase**
+**⚠️ Pre-Event Validation Phase**
 
-This project is under active development for CozySummit Virtual 2025 (December 3). A complete quick start guide will be available after the demo.
+This project is under active validation for CozySummit Virtual 2026 (May 26). A complete quick start guide will be available after the event.
 
 ### Available Now
 
@@ -83,7 +83,7 @@ These are pure "matchbox" and "talos" OCI images compatible with:
 ./validate-patch.sh
 ```
 
-**Full deployment guide coming post-demo** 🎯
+**Full deployment guide coming post-event** 🎯
 
 ---
 
@@ -92,7 +92,7 @@ These are pure "matchbox" and "talos" OCI images compatible with:
 **✅ Completed (November 2025)**:
 ARM64 Talos builds, CI/CD pipeline, container images, TDG methodology, ADR documentation
 
-**🎯 Demo Goals (December 3, 2025)**:
+**🎯 Event Goals (May 26, 2026)**:
 Live WebAssembly demo, VPC subnet router access, cost transparency, home lab transition strategy
 
 ---

--- a/patches/04-arm64-default-platform.patch
+++ b/patches/04-arm64-default-platform.patch
@@ -1,0 +1,13 @@
+diff --git a/hack/common-envs.mk b/hack/common-envs.mk
+index 9b8db5d..8ba4aaf 100644
+--- a/hack/common-envs.mk
++++ b/hack/common-envs.mk
+@@ -10,7 +10,7 @@ TAG = $(shell git describe --tags --exact-match --match 'v*' 2>/dev/null || echo
+ PUSH := 1
+ LOAD := 0
+ BUILDER ?=
+-PLATFORM ?= 
++PLATFORM ?= linux/arm64
+ BUILDX_EXTRA_ARGS ?=
+ COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags --match 'v*'))
+ 

--- a/patches/06-kubeovn-manifest-list-retag.patch
+++ b/patches/06-kubeovn-manifest-list-retag.patch
@@ -1,0 +1,32 @@
+diff --git a/Makefile b/Makefile
+index 5041ac6..842a3e7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -23,6 +23,7 @@ build: build-deps
+ 	make -C packages/system/cilium image
+ 	make -C packages/system/linstor image
+ 	make -C packages/system/linstor-gui image
++	make -C packages/system/kubeovn image
+ 	make -C packages/system/kubeovn-webhook image
+ 	make -C packages/system/kubeovn-plunger image
+ 	make -C packages/system/dashboard image
+diff --git a/packages/system/kubeovn/Makefile b/packages/system/kubeovn/Makefile
+index 4562904..0434f83 100644
+--- a/packages/system/kubeovn/Makefile
++++ b/packages/system/kubeovn/Makefile
+@@ -3,6 +3,15 @@ export NAMESPACE=cozy-$(NAME)
+ 
+ include ../../../hack/common-envs.mk
+ include ../../../hack/package.mk
++KUBEOVN_VERSION=$(shell yq e '.global.images.kubeovn.tag' values.yaml | cut -d@ -f1)
++
++image:
++	crane copy --all docker.io/kubeovn/kube-ovn:$(KUBEOVN_VERSION) $(REGISTRY)/kubeovn:$(call settag,$(KUBEOVN_VERSION))
++	REPOSITORY="$(REGISTRY)" \
++		yq -i '.global.registry.address = strenv(REPOSITORY)' values.yaml
++	TAG="$(call settag,$(KUBEOVN_VERSION))" \
++		yq -i '.global.images.kubeovn.tag = strenv(TAG)' values.yaml
++
+ 
+ update:
+ 	rm -rf charts values.yaml Chart.yaml


### PR DESCRIPTION
## Summary

JUNIPER-8 session work: build CozyStack v1.3.3 in-tree images for `linux/arm64` and ship to `ghcr.io/urmanac/cozystack-assets/*`.

## Root Cause Fixed

`hack/common-envs.mk` sets `PLATFORM ?=` (empty), so GitHub's amd64 runners produce amd64-only images for every package. Additionally, the `kubeovn` retag copied only the amd64 manifest to GHCR, pinning a `@sha256:` digest that breaks on arm64 nodes with `exec format error`.

## New Patches

Both validated with `git apply --check` on a clean v1.3.3 clone.

### `patches/04-arm64-default-platform.patch`
Sets `PLATFORM ?= linux/arm64` in `hack/common-envs.mk`. This injects `--platform=linux/arm64` into `$(BUILDX_ARGS)` for every package's `make image` target, including `cozystack-operator`, `matchbox`, and all system controllers.

### `patches/06-kubeovn-manifest-list-retag.patch`
Adds an `image:` target to `packages/system/kubeovn/Makefile` using `crane copy --all` to preserve the full manifest list (arm64 + amd64) when retagging from `docker.io/kubeovn/kube-ovn` to our registry. Drops the amd64-pinning `@sha256:` digest from `values.yaml`. Also adds `kubeovn` to the top-level `build:` target.

## Workflow Changes

Patch 04 is now applied in both `build-talos-images.yml` and `release-talos-assets.yml` before the variant-specific patches, so matchbox and the operator get correct `linux/arm64` platform labels.

## Docs

- `docs/ION-7-ORBITAL-REBOOT.md`: appended full arm64 image audit (root cause, image table, kubeovn manifest confirmed amd64-only, fix plan)
- `docs/JUNIPER-8-ARM64-COZYSTACK-IMAGES.md`: session plan including build workflow matrix, HelmRelease override mechanism, execution order
- `.github/skills/cozystack-patch-workflow/SKILL.md`: reusable agent skill codifying the clone → edit → git diff → git apply --check → register → commit cycle
- CozySummit badge and event dates updated to 2026 (May 26)