### PR TITLE
fix(release): retag :latest FROM canonical immutable tag, not the other way around

### DIFF
--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -123,9 +123,22 @@ jobs:
 
       - name: Tag GHCR OCI images at release
         run: |
+          # Tagging direction: always retag FROM an immutable canonical tag
+          # (built by build-talos-images.yml against the same CozyStack ref,
+          # so the upstream Makefile produces matchbox:$(TAG) and
+          # matchbox:$(TALOS_VERSION)-$(TAG) where TAG=v1.3.3). We then
+          # alias :latest from that canonical tag.
+          #
+          # The prior implementation read FROM :latest, which is mutable and
+          # could alias stale digests into the release composite tag. See
+          # docs/ION-7-ORBITAL-REBOOT.md "Release tag drift bug".
           RELEASE_TAG="${{ github.ref_name }}"
           # TALOS_VERSION was written to GITHUB_ENV by the build step
           TALOS_VERSION="$TALOS_VERSION"
+          # Canonical immutable matchbox tag produced by upstream Makefile when
+          # cozystack-upstream HEAD is at the v1.3.3 git tag:
+          #   matchbox:$(TALOS_VERSION)-$(TAG)  →  matchbox:v1.12.7-v1.3.3
+          MATCHBOX_CANONICAL_TAG="${TALOS_VERSION}-${RELEASE_TAG}"
           # Composite tag: ties the matchbox image to both the Talos version it embeds
           # and the CozyStack repo release that produced it.
           MATCHBOX_TAG="talos-${TALOS_VERSION}-cozy-${RELEASE_TAG}"
@@ -138,19 +151,36 @@ jobs:
           echo "ℹ️  Talos installer images already carry Talos version tag (${TALOS_VERSION}) — not adding repo release tag."
 
           # Matchbox image:
-          #   Add composite tag so the exact Talos+CozyStack combination is reproducible.
+          #   Retag the canonical immutable tag onto the composite tag, then alias
+          #   :latest from the same canonical source so :latest always reflects the
+          #   most recently released bits.
           for VARIANT in spin-tailscale spin-only; do
             BASE="${{ env.REGISTRY }}/talos/cozystack-${VARIANT}"
-            echo "Tagging ${BASE}/matchbox:latest → :${MATCHBOX_TAG}"
-            crane tag "${BASE}/matchbox:latest" "${MATCHBOX_TAG}" \
-              && echo "✅ ${VARIANT}/matchbox tagged ${MATCHBOX_TAG}" \
-              || echo "⚠️  Could not tag ${VARIANT}/matchbox (image may not exist yet)"
+            SRC="${BASE}/matchbox:${MATCHBOX_CANONICAL_TAG}"
+            echo "Tagging ${SRC} → :${MATCHBOX_TAG}"
+            if crane tag "${SRC}" "${MATCHBOX_TAG}"; then
+              echo "✅ ${VARIANT}/matchbox tagged ${MATCHBOX_TAG}"
+              echo "Tagging ${SRC} → :latest"
+              crane tag "${SRC}" latest \
+                && echo "✅ ${VARIANT}/matchbox latest now points to ${MATCHBOX_CANONICAL_TAG}" \
+                || echo "⚠️  Could not retag ${VARIANT}/matchbox to :latest"
+            else
+              echo "⚠️  Canonical source tag ${SRC} not found — build-talos-images.yml must run first"
+            fi
           done
 
-          # Operator: a CozyStack component, tagged with the repo release.
-          crane tag "${{ env.REGISTRY }}/cozystack-operator:latest" "${RELEASE_TAG}" \
-            && echo "✅ operator tagged ${RELEASE_TAG}" \
-            || echo "⚠️  Could not tag operator"
+          # Operator: canonical immutable tag is :v1.3.3 (the CozyStack ref the
+          # build was performed against). Alias :latest from that tag.
+          OPERATOR_SRC="${{ env.REGISTRY }}/cozystack-operator:${RELEASE_TAG}"
+          if crane digest "${OPERATOR_SRC}" >/dev/null 2>&1; then
+            echo "✅ operator canonical tag ${RELEASE_TAG} already present"
+            echo "Tagging ${OPERATOR_SRC} → :latest"
+            crane tag "${OPERATOR_SRC}" latest \
+              && echo "✅ operator :latest now points to ${RELEASE_TAG}" \
+              || echo "⚠️  Could not retag operator to :latest"
+          else
+            echo "⚠️  Canonical source ${OPERATOR_SRC} not found — build-talos-images.yml must run first"
+          fi
 
       - name: Create GitHub Release
         env:

--- a/docs/ION-7-ORBITAL-REBOOT.md
+++ b/docs/ION-7-ORBITAL-REBOOT.md
@@ -147,3 +147,65 @@ The `@sha256:...` digest pins to the amd64 manifest specifically. On arm64 nodes
 3. The `kubeovn` image specifically: retag the upstream arm64 manifest to our registry rather than retagging a single-arch amd64 manifest.
 4. Override image refs in `talm-chart/` or via `HelmRelease` patches to point at `ghcr.io/urmanac/cozystack-assets/*` ARM64 images.
 5. Delete stale tags, push PR to `docs/arm64-pxe-guide-refresh` → main → tag → CI publishes new bundle.
+
+---
+
+## Release tag drift bug (found 2026-05-15)
+
+### Symptom
+
+After tagging `v1.3.3` and watching the release workflow succeed, the GHCR UI showed:
+
+- `matchbox:talos-v1.12.7-cozy-v1.3.3` — published 5 minutes ago, digest X
+- `matchbox:latest` — published 6 months ago, **same digest X**
+
+This was suspicious: a fresh release tag was aliased to whatever `:latest`
+happened to point to, *not* to a freshly built image.
+
+### Root cause
+
+[release-talos-assets.yml](.github/workflows/release-talos-assets.yml)
+retagged in the wrong direction:
+
+```bash
+# BEFORE (broken):
+crane tag matchbox:latest         talos-v1.12.7-cozy-v1.3.3
+crane tag cozystack-operator:latest  v1.3.3
+```
+
+`:latest` is mutable — it can be updated by any prior workflow run (or stay
+stale if no recent build pushed). Reading *from* `:latest` means the release
+composite tag inherits whatever `:latest` happens to be pointing at when the
+release fires, with no guarantee the bits are the ones built in this release
+cycle.
+
+### Fix
+
+Always retag *from* an immutable canonical tag:
+
+- matchbox: `:${TALOS_VERSION}-${RELEASE_TAG}` (e.g. `v1.12.7-v1.3.3`),
+  produced by upstream Makefile when cozystack-upstream HEAD is at the
+  `v1.3.3` git tag (`docker buildx --tag matchbox:$(TALOS_VERSION)-$(TAG)`).
+- operator: `:${RELEASE_TAG}` (e.g. `v1.3.3`), produced by
+  `make image-operator` against cozystack `v1.3.3`.
+
+Then alias `:latest` *from* the canonical tag, so `:latest` always reflects
+the most recently released bits.
+
+```bash
+# AFTER (correct):
+SRC=matchbox:v1.12.7-v1.3.3                # immutable, built this cycle
+crane tag "$SRC" talos-v1.12.7-cozy-v1.3.3 # composite
+crane tag "$SRC" latest                    # alias to fresh canonical
+
+SRC=cozystack-operator:v1.3.3              # immutable, built this cycle
+crane tag "$SRC" latest                    # alias to fresh canonical
+```
+
+### Why the symptom matched the released bits anyway
+
+In this specific run the upstream `:latest` happened to already be the
+correct digest because `build-talos-images.yml` had just run on the merge
+to main and pushed `:latest` *and* `:v1.12.7-v1.3.3` to the same digest.
+The release tag therefore aliased the right content — but only by
+coincidence. The fix removes the coincidence.


### PR DESCRIPTION
## Bug

The release-talos-assets workflow was retagging FROM `:latest`:

```bash
crane tag matchbox:latest             talos-v1.12.7-cozy-v1.3.3
crane tag cozystack-operator:latest   v1.3.3
```

`:latest` is mutable. The release composite tag therefore inherited whatever digest `:latest` happened to point to at release time — not necessarily the bits built in this release cycle.

Spotted in the v1.3.3 release run: GHCR showed `matchbox:talos-v1.12.7-cozy-v1.3.3` published 5 minutes ago AND `matchbox:latest` published 6 months ago — same digest. The release "worked" only because `build-talos-images.yml` had just pushed `:latest` to the freshly built digest on merge to main.

## Fix

Always retag *from* an immutable canonical tag built this cycle, then alias `:latest` *from* it.

- **matchbox**: source = `:$TALOS_VERSION-$RELEASE_TAG` (e.g. `v1.12.7-v1.3.3`), produced by upstream Makefile when cozystack-upstream HEAD is at the `v1.3.3` git tag.
- **operator**: source = `:$RELEASE_TAG` (e.g. `v1.3.3`), produced by `make image-operator` against cozystack `v1.3.3`.

Both then alias `:latest` from the canonical source so `:latest` always reflects the most recently released bits.

## Docs

Documented in [docs/ION-7-ORBITAL-REBOOT.md](docs/ION-7-ORBITAL-REBOOT.md) under "Release tag drift bug".