### PR TITLE
fix(arm64): build every in-tree CozyStack image as ARM64 (patch 07 + workflow restructure)

### DIFF
--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -15,13 +15,81 @@ env:
   REGISTRY: ghcr.io/urmanac/cozystack-assets
 
 jobs:
-  # Build OCI images (talos installer, matchbox, operator) for both extension
-  # variants before the metal image job fires. This makes the release workflow
-  # fully self-contained: canonical GHCR tags are guaranteed to exist when the
-  # retag step runs, regardless of whether build-talos-images.yml ran recently
-  # on main. Without this job, tagging without a prior push to main would
-  # produce a release where the composite/latest tags are absent or stale.
-  build-oci-images:
+  # Stage 1: build all in-tree CozyStack images as linux/arm64 and push to our
+  # registry. This is a single (non-matrix) job because nothing besides
+  # core/talos varies by extension variant. Patches:
+  #   04 — set PLATFORM ?= linux/arm64 (every docker buildx defaults to arm64)
+  #   06 — add kubeovn image target that copies the upstream multi-arch
+  #        manifest list and rewrites values.yaml to our registry
+  #   07 — skip dashboard (amd64-hardcoded in its Dockerfile) and core/talos
+  #        (handled per-variant in build-talos-variants)
+  #
+  # `make build` cascades through every in-tree package's `make image` target
+  # which both (a) builds and pushes the image and (b) rewrites the chart's
+  # values.yaml to reference $(REGISTRY). The final step builds the
+  # cozystack-operator with the rewritten chart bundle baked in, so the
+  # ExternalArtifacts the operator serves at runtime point at our registry.
+  build-cozystack-images:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo jq helm
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then CRANE_ARCH="x86_64"; else CRANE_ARCH="arm64"; fi
+          curl -sSL https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_${CRANE_ARCH}.tar.gz \
+            | sudo tar xz -C /usr/local/bin crane
+          if [ "$ARCH" = "x86_64" ]; then YQ_ARCH="amd64"; else YQ_ARCH="arm64"; fi
+          sudo wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${YQ_ARCH} -O /usr/bin/yq
+          sudo chmod +x /usr/bin/yq
+          crane version && yq --version && helm version --short
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | skopeo login ghcr.io \
+            --username ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io \
+            --username ${{ github.actor }} --password-stdin
+
+      - name: Clone upstream CozyStack
+        run: |
+          COZYSTACK_REF=$(grep -oP "default: '(v[0-9]+\.[0-9]+\.[0-9]+)'" \
+            .github/workflows/build-talos-images.yml | head -1 | grep -oP "v[0-9]+\.[0-9]+\.[0-9]+")
+          echo "Building CozyStack images from $COZYSTACK_REF"
+          echo "COZYSTACK_REF=$COZYSTACK_REF" >> $GITHUB_ENV
+          git clone --branch "$COZYSTACK_REF" --depth 1 \
+            https://github.com/cozystack/cozystack.git cozystack-upstream
+
+      - name: Apply ARM64 patches (shared build)
+        run: |
+          cd cozystack-upstream
+          git apply ../patches/04-arm64-default-platform.patch
+          git apply ../patches/06-kubeovn-manifest-list-retag.patch
+          git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          echo "Patches applied:"
+          git status --porcelain
+
+      - name: Build all in-tree images (make build)
+        run: |
+          cd cozystack-upstream
+          # `make build` runs every per-package `make image` target. Each one
+          # docker buildx builds for linux/arm64 (patch 04), pushes to our
+          # registry, and rewrites that chart's values.yaml. The final
+          # core/installer build packages the rewritten charts into the
+          # cozystack-operator image.
+          make build REGISTRY="${{ env.REGISTRY }}" PUSH=1
+
+  # Stage 2: per-variant talos installer + matchbox images. These are the only
+  # images that genuinely differ between spin-tailscale and spin-only because
+  # the extension list is baked into the talos installer at build time.
+  build-talos-variants:
     runs-on: ubuntu-24.04-arm
     permissions:
       packages: write
@@ -58,12 +126,12 @@ jobs:
         run: |
           COZYSTACK_REF=$(grep -oP "default: '(v[0-9]+\.[0-9]+\.[0-9]+)'" \
             .github/workflows/build-talos-images.yml | head -1 | grep -oP "v[0-9]+\.[0-9]+\.[0-9]+")
-          echo "Building OCI images from CozyStack $COZYSTACK_REF (variant: ${{ matrix.extension_variant }})"
+          echo "Building talos variant ${{ matrix.extension_variant }} from CozyStack $COZYSTACK_REF"
           echo "COZYSTACK_REF=$COZYSTACK_REF" >> $GITHUB_ENV
           git clone --branch "$COZYSTACK_REF" --depth 1 \
             https://github.com/cozystack/cozystack.git cozystack-upstream
 
-      - name: Apply ARM64 patches
+      - name: Apply ARM64 + variant patches
         run: |
           cd cozystack-upstream
           EXTENSION_VARIANT="${{ matrix.extension_variant }}"
@@ -76,10 +144,8 @@ jobs:
           git apply ../patches/02-makefile-architecture-variables.patch
           chmod +x packages/core/talos/hack/gen-profiles.sh
           chmod +x packages/core/talos/hack/gen-versions.sh
-          echo "Patches applied for $EXTENSION_VARIANT:"
-          git status --porcelain
 
-      - name: Build and push OCI images
+      - name: Build and push talos + matchbox
         run: |
           cd cozystack-upstream/packages/core/talos
           UPSTREAM_TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/installer.yaml)
@@ -89,18 +155,7 @@ jobs:
           fi
           echo "Upstream-pinned Talos version: $UPSTREAM_TALOS_VERSION"
           bash hack/gen-profiles.sh "$UPSTREAM_TALOS_VERSION"
-          VARIANT="${{ matrix.extension_variant }}"
-          VARIANT_REGISTRY="${{ env.REGISTRY }}/talos/cozystack-${VARIANT}"
-
-          # Operator is a shared image (not variant-specific). Build it once from
-          # the spin-only leg to avoid a race where both matrix legs push different
-          # digests to the same canonical tag simultaneously.
-          if [ "$VARIANT" = "spin-only" ]; then
-            echo "Building cozystack-operator (shared, spin-only leg only)..."
-            make -C ../installer image-operator \
-              REGISTRY="${{ env.REGISTRY }}" \
-              PUSH=1
-          fi
+          VARIANT_REGISTRY="${{ env.REGISTRY }}/talos/cozystack-${{ matrix.extension_variant }}"
 
           echo "Building talos installer image (REGISTRY=$VARIANT_REGISTRY)..."
           make image-talos REGISTRY="$VARIANT_REGISTRY"
@@ -109,7 +164,7 @@ jobs:
           make image-matchbox REGISTRY="$VARIANT_REGISTRY" PUSH=1
 
   build-metal-image:
-    needs: build-oci-images
+    needs: [build-cozystack-images, build-talos-variants]
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write    # create GitHub Release + upload assets

--- a/patches/07-arm64-skip-amd64-only-builds.patch
+++ b/patches/07-arm64-skip-amd64-only-builds.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile b/Makefile
+index 842a3e7..3251b4b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -26,7 +26,6 @@ build: build-deps
+ 	make -C packages/system/kubeovn image
+ 	make -C packages/system/kubeovn-webhook image
+ 	make -C packages/system/kubeovn-plunger image
+-	make -C packages/system/dashboard image
+ 	make -C packages/system/metallb image
+ 	make -C packages/system/kamaji image
+ 	make -C packages/system/multus image
+@@ -34,7 +33,6 @@ build: build-deps
+ 	make -C packages/system/objectstorage-controller image
+ 	make -C packages/system/grafana-operator image
+ 	make -C packages/core/testing image
+-	make -C packages/core/talos image
+ 	make -C packages/core/platform image
+ 	make -C packages/core/installer image
+ 	make manifests


### PR DESCRIPTION
## Problem

The v1.3.3 release only built three OCI images for arm64: `talos`, `matchbox`, and `cozystack-operator`. Every other in-tree image (~20 of them) was pulled at runtime from `ghcr.io/cozystack/cozystack/*` — which upstream publishes **amd64-only**.

On the test cluster: kube-ovn pods crashloop with `exec format error` because the chart references `ghcr.io/cozystack/cozystack/kubeovn:v1.15.10@sha256:741299c...` (amd64-only). The same will happen for cilium, kamaji, multus, metallb, linstor, kubevirt-cdi, monitoring, every cozystack-* controller, and the bucket/objectstorage/grafana-operator system charts — none of them can come up on arm64 nodes.

## How CozyStack's build wires charts to images

Each in-tree package's `make image` target does **two** things:

1. `docker buildx build` for `$(PLATFORM)` and push to `$(REGISTRY)`
2. `yq -i` rewrite that chart's own `values.yaml` to reference `$(REGISTRY)`

Then `make build` cascades through every package in order, with `core/installer` (the operator) built last. The operator image bundles the *rewritten* chart tarballs, so the ExternalArtifacts it serves at runtime already point at our registry.

So the fix is just: actually run `make build` with our REGISTRY, on arm64.

## Changes

### `patches/07-arm64-skip-amd64-only-builds.patch` (new)

Drops two lines from upstream's top-level `build:` target:

- `packages/system/dashboard` — its Dockerfiles hardcode `--platform=linux/amd64`, can't be rebuilt for arm64 without forking the package
- `packages/core/talos` — handled per-variant in stage 2 (needs the variant-specific extension patches applied)

### `release-talos-assets.yml` (restructured)

Replaces the per-variant matrix that only built three images with two stages:

```
build-cozystack-images        (single, no matrix)
    └─ apply patches 04 + 06 + 07
    └─ make build REGISTRY=$REGISTRY PUSH=1
       → cilium, kubeovn, kamaji, multus, metallb, linstor, linstor-gui,
         kubeovn-webhook, kubeovn-plunger, monitoring, cozystack-api,
         cozystack-controller, backup-controller, backupstrategy-controller,
         lineage-controller-webhook, bucket, objectstorage-controller,
         grafana-operator, http-cache, mariadb, clickhouse, kubernetes,
         core/testing, core/platform, core/installer (operator)

build-talos-variants          (matrix [spin-tailscale, spin-only])
    └─ apply patches 04 + variant + 02
    └─ make image-talos, image-matchbox
       → talos:v1.12.7, matchbox:v1.12.7-v1.3.3 per variant

build-metal-image             (needs both above)
    └─ existing logic: dd metal.raw.xz, retag composites, gh release create
```

## Validation

All patches `git apply --check` cleanly on a fresh `v1.3.3` clone:

```
ALL PATCHES VALIDATE  (04 + 06 + 07)
```

## Out of scope / known gaps

- **dashboard chart**: stays amd64-only (upstream hardcodes platform). Won't run on pure-arm64 nodes. Can be skipped at `Cozystack` CR level if needed.
- **kubevirt**: still references upstream `quay.io/kubevirt/*` (arm64 experimental upstream). Out of scope.
- `build-talos-images.yml` (on-push) is left unchanged. The release workflow is now the comprehensive, canonical path.

## Follow-up

After merge:
1. Re-tag `v1.3.3` to trigger the new workflow
2. Get the test cluster back into Talos maintenance mode  
3. Reapply talm config → `helm install cozystack-operator` with `cozystackOperator.image=ghcr.io/urmanac/cozystack-assets/cozystack-operator:v1.3.3` (the freshly built one)
4. Watch ExternalArtifacts spawn HelmReleases that reference our registry