### PR TITLE
fix(arm64): skip linstor and linstor-gui from make build

### DIFF
--- a/patches/07-arm64-skip-amd64-only-builds.patch
+++ b/patches/07-arm64-skip-amd64-only-builds.patch
@@ -1,8 +1,13 @@
 diff --git a/Makefile b/Makefile
-index 842a3e7..3251b4b 100644
+index 842a3e7..f49c917 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -26,7 +26,6 @@ build: build-deps
+@@ -21,12 +21,9 @@ build: build-deps
+ 	make -C packages/system/backupstrategy-controller image
+ 	make -C packages/system/lineage-controller-webhook image
+ 	make -C packages/system/cilium image
+-	make -C packages/system/linstor image
+-	make -C packages/system/linstor-gui image
  	make -C packages/system/kubeovn image
  	make -C packages/system/kubeovn-webhook image
  	make -C packages/system/kubeovn-plunger image
@@ -10,7 +15,7 @@ index 842a3e7..3251b4b 100644
  	make -C packages/system/metallb image
  	make -C packages/system/kamaji image
  	make -C packages/system/multus image
-@@ -34,7 +33,6 @@ build: build-deps
+@@ -34,7 +31,6 @@ build: build-deps
  	make -C packages/system/objectstorage-controller image
  	make -C packages/system/grafana-operator image
  	make -C packages/core/testing image


### PR DESCRIPTION
## Failure

`make build` made it through ~14 images then failed on `piraeus-server`:

```
#17 5.534 /linstor-server/tools/protoc-31.1/bin/protoc: 1: Syntax error: ")" unexpected
#17 5.534 make: *** [Makefile:17: ../generated-src/com/linbit/./common/RscGrpOuterClass.java] Error 2
```

That syntax error is `/bin/sh` trying to read an ELF binary. Linstor's gradle build downloads `protoc-31.1-linux-x86_64.tar.gz` unconditionally, then tries to exec it on arm64.

## Why we are skipping rather than fixing

- LINBIT does not publish arm64 linstor-server packages
- The gradle build is not arm64-aware (protoc download is hardcoded)
- Patching protoc alone would not solve the larger Java-to-native bridge linstor uses (libdrbdvol, etc.)
- LINBIT's own DEB/RPM repos do not carry arm64

This is the same accepted gap class as `dashboard` (amd64-hardcoded Dockerfile) and `kubevirt` (upstream arm64 is experimental).

## Fix

Extend `patches/07-arm64-skip-amd64-only-builds.patch` to also drop:

```
make -C packages/system/linstor image
make -C packages/system/linstor-gui image
```

from upstream's top-level `build:` target.

## Validation

```
ALL PATCHES VALIDATE  (04 + 06 + 07)
```

## Followup

After merge: force-move `v1.3.3` to `main` again to retrigger the release.

## Future hardening

You asked whether we can vet remaining builds locally. We can: spin up an arm64 Docker context (Docker Desktop with Rosetta off is native on Apple Silicon) and run `cd cozystack-upstream && make build REGISTRY=ghcr.io/urmanac/cozystack-assets-test PUSH=0` after applying patches 04+06+07. That would surface arch-specific Dockerfile failures in minutes instead of waiting on CI. Worth doing once we have a green release, so future patches are tested before we burn workflow minutes.
