### PR TITLE
ci: Complete release workflow updates for Talos 1.13.2 and HailoRT

### DIFF
--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        extension_variant: [spin-tailscale, spin-only]
+        extension_variant: [spin-tailscale, spin-hailort, spin-only]
 
     steps:
       - name: Checkout repository
@@ -154,6 +154,8 @@ jobs:
           git apply ../patches/04-arm64-default-platform.patch
           if [ "$EXTENSION_VARIANT" = "spin-only" ]; then
             git apply ../patches/03-arm64-spin-only.patch
+          elif [ "$EXTENSION_VARIANT" = "spin-hailort" ]; then
+            git apply ../patches/08-arm64-spin-hailort.patch
           else
             git apply ../patches/01-arm64-spin-tailscale.patch
           fi
@@ -164,13 +166,22 @@ jobs:
       - name: Build and push talos + matchbox
         run: |
           cd cozystack-upstream/packages/core/talos
-          UPSTREAM_TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/installer.yaml)
-          if [ -z "$UPSTREAM_TALOS_VERSION" ]; then
-            echo "::error::Could not derive Talos version from upstream installer.yaml"
-            exit 1
+          
+          # Parse the release tag to see if it overrides the Talos version.
+          FULL_TAG="${{ github.ref_name }}"
+          if [[ "$FULL_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(1\.[0-9]+\.[0-9]+)$ ]]; then
+            TALOS_VER="${BASH_REMATCH[2]}"
+          else
+            UPSTREAM_TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/installer.yaml)
+            if [ -z "$UPSTREAM_TALOS_VERSION" ]; then
+              echo "::error::Could not derive Talos version from upstream installer.yaml"
+              exit 1
+            fi
+            TALOS_VER="$UPSTREAM_TALOS_VERSION"
           fi
-          echo "Upstream-pinned Talos version: $UPSTREAM_TALOS_VERSION"
-          bash hack/gen-profiles.sh "$UPSTREAM_TALOS_VERSION"
+          
+          echo "Building Talos version: $TALOS_VER"
+          bash hack/gen-profiles.sh "$TALOS_VER"
           VARIANT_REGISTRY="${{ env.REGISTRY }}/talos/cozystack-${{ matrix.extension_variant }}"
 
           echo "Building talos installer image (REGISTRY=$VARIANT_REGISTRY)..."


### PR DESCRIPTION
## Description
This PR completes the updates to the `release-talos-assets.yml` workflow required for the new `spin-hailort` variant and composite tags (e.g., `v1.4.0-1.13.2`).

## Key Fixes
- **Matrix Update:** Added `spin-hailort` to the `build-talos-variants` job matrix.
- **Patch Application:** Updated the patching logic in the job to correctly apply `08-arm64-spin-hailort.patch`.
- **Version Parsing:** Updated the profile generation step to parse the composite tag and override the Talos version, mirroring the logic in the main build workflow.