### PR TITLE
ci: fix missing 'v' prefix when parsing Talos version

### DIFF
--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -170,7 +170,7 @@ jobs:
           # Parse the release tag to see if it overrides the Talos version.
           FULL_TAG="${{ github.ref_name }}"
           if [[ "$FULL_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(1\.[0-9]+\.[0-9]+)$ ]]; then
-            TALOS_VER="${BASH_REMATCH[2]}"
+            TALOS_VER="v${BASH_REMATCH[2]}"
           else
             UPSTREAM_TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/installer.yaml)
             if [ -z "$UPSTREAM_TALOS_VERSION" ]; then
@@ -239,22 +239,27 @@ jobs:
         run: |
           cd cozystack-upstream/packages/core/talos
 
-          # Pin Talos version to the upstream-committed profile (matches whatever
-          # CozyStack release we're tracking). See build-talos-images.yml for the
-          # rationale — gen-profiles.sh would otherwise pick latest upstream tag.
-          UPSTREAM_TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/installer.yaml)
-          if [ -z "$UPSTREAM_TALOS_VERSION" ]; then
-            echo "::error::Could not derive Talos version from upstream installer.yaml"
-            exit 1
+          # Parse the release tag to see if it overrides the Talos version.
+          FULL_TAG="${{ github.ref_name }}"
+          if [[ "$FULL_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(1\.[0-9]+\.[0-9]+)$ ]]; then
+            TALOS_VER="v${BASH_REMATCH[2]}"
+          else
+            UPSTREAM_TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/installer.yaml)
+            if [ -z "$UPSTREAM_TALOS_VERSION" ]; then
+              echo "::error::Could not derive Talos version from upstream installer.yaml"
+              exit 1
+            fi
+            TALOS_VER="$UPSTREAM_TALOS_VERSION"
           fi
-          echo "Upstream-pinned Talos version: $UPSTREAM_TALOS_VERSION"
-          bash hack/gen-profiles.sh "$UPSTREAM_TALOS_VERSION"
+          
+          echo "Building Talos version: $TALOS_VER"
+          bash hack/gen-profiles.sh "$TALOS_VER"
 
           echo "Generated profile:"
           cat images/talos/profiles/metal.yaml
           TALOS_VERSION=$(awk '/^version:/ {print $2; exit}' images/talos/profiles/metal.yaml)
-          if [ "$TALOS_VERSION" != "$UPSTREAM_TALOS_VERSION" ]; then
-            echo "::error::Regenerated metal.yaml has $TALOS_VERSION but expected $UPSTREAM_TALOS_VERSION"
+          if [ "$TALOS_VERSION" != "$TALOS_VER" ]; then
+            echo "::error::Regenerated metal.yaml has $TALOS_VERSION but expected $TALOS_VER"
             exit 1
           fi
           echo "TALOS_VERSION=$TALOS_VERSION" >> $GITHUB_ENV
@@ -305,7 +310,7 @@ jobs:
           FULL_TAG="${{ github.ref_name }}"
           if [[ "$FULL_TAG" =~ ^(v[0-9]+\.[0-9]+\.[0-9]+)-(1\.[0-9]+\.[0-9]+)$ ]]; then
             COZY_VER="${BASH_REMATCH[1]}"
-            TALOS_REQ="${BASH_REMATCH[2]}"
+            TALOS_REQ="v${BASH_REMATCH[2]}"
             # If the tag was v1.4.0-1.13.2, the cozystack version to pull is v1.4.0
           else
             COZY_VER="$FULL_TAG"


### PR DESCRIPTION
## Description
The build failed with `MANIFEST_UNKNOWN` because `crane export ghcr.io/siderolabs/extensions:1.13.2` was missing the `v` prefix. 

## Fix
This PR ensures that when a composite tag (e.g. `v1.4.0-1.13.2`) is parsed, the extracted Talos version string explicitly prepends the `v` (creating `v1.13.2`) before it is passed to `gen-profiles.sh`. It also ensures that the `build-metal-image` job correctly parses and uses the overridden Talos version instead of defaulting to the upstream pin.