### PR TITLE
feat: enable ARM64 builds for Linstor and Dashboard

### DIFF
--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -116,12 +116,13 @@ jobs:
           cd cozystack-upstream
           git checkout v1.4.0
 
-      - name: Apply ARM64 patches
+      - name: Apply ARM64 patches (shared build)
         run: |
           cd cozystack-upstream
           git apply ../patches/04-arm64-default-platform.patch
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
 
       - name: Build parallel package group
         run: |
@@ -131,9 +132,9 @@ jobs:
           export PUSH=1
           
           if [ "$GROUP" = "apps" ]; then
-            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes"
+            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes packages/system/dashboard"
           elif [ "$GROUP" = "system-base" ]; then
-            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook"
+            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook packages/system/linstor packages/system/linstor-gui"
           elif [ "$GROUP" = "system-net" ]; then
             DIRS="packages/system/cilium packages/system/kubeovn packages/system/kubeovn-webhook packages/system/kubeovn-plunger"
           elif [ "$GROUP" = "system-cloud" ]; then
@@ -195,6 +196,7 @@ jobs:
           git apply ../patches/04-arm64-default-platform.patch
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
 
       - name: Build operator and manifests
         run: |
@@ -257,6 +259,9 @@ jobs:
             git apply ../patches/01-arm64-spin-tailscale.patch
           fi
           git apply ../patches/02-makefile-architecture-variables.patch
+          git apply ../patches/06-kubeovn-manifest-list-retag.patch
+          git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
           chmod +x packages/core/talos/hack/gen-profiles.sh
           chmod +x packages/core/talos/hack/gen-versions.sh
 

--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -67,6 +67,7 @@ jobs:
           git apply ../patches/04-arm64-default-platform.patch
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
 
       - name: Build parallel package group
         run: |
@@ -75,9 +76,9 @@ jobs:
           export PUSH=1
           
           if [ "$GROUP" = "apps" ]; then
-            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes"
+            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes packages/system/dashboard"
           elif [ "$GROUP" = "system-base" ]; then
-            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook"
+            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook packages/system/linstor packages/system/linstor-gui"
           elif [ "$GROUP" = "system-net" ]; then
             DIRS="packages/system/cilium packages/system/kubeovn packages/system/kubeovn-webhook packages/system/kubeovn-plunger"
           elif [ "$GROUP" = "system-cloud" ]; then
@@ -142,6 +143,7 @@ jobs:
           git apply ../patches/04-arm64-default-platform.patch
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
 
       - name: Build operator and manifests
         run: |
@@ -206,6 +208,9 @@ jobs:
             git apply ../patches/01-arm64-spin-tailscale.patch
           fi
           git apply ../patches/02-makefile-architecture-variables.patch
+          git apply ../patches/06-kubeovn-manifest-list-retag.patch
+          git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
           chmod +x packages/core/talos/hack/gen-profiles.sh
           chmod +x packages/core/talos/hack/gen-versions.sh
 
@@ -265,6 +270,9 @@ jobs:
           git apply ../patches/04-arm64-default-platform.patch
           git apply ../patches/03-arm64-spin-only.patch
           git apply ../patches/02-makefile-architecture-variables.patch
+          git apply ../patches/06-kubeovn-manifest-list-retag.patch
+          git apply ../patches/07-arm64-skip-amd64-only-builds.patch
+          git apply ../patches/09-arm64-linstor-dashboard.patch
           chmod +x packages/core/talos/hack/gen-profiles.sh
           chmod +x packages/core/talos/hack/gen-versions.sh
 

--- a/patches/07-arm64-skip-amd64-only-builds.patch
+++ b/patches/07-arm64-skip-amd64-only-builds.patch
@@ -1,25 +1,12 @@
 diff --git a/Makefile b/Makefile
-index 842a3e7..f49c917 100644
+index 5041ac6..842a3e7 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -21,12 +21,9 @@ build: build-deps
- 	make -C packages/system/backupstrategy-controller image
- 	make -C packages/system/lineage-controller-webhook image
+@@ -23,6 +23,7 @@ build: build-deps
  	make -C packages/system/cilium image
--	make -C packages/system/linstor image
--	make -C packages/system/linstor-gui image
- 	make -C packages/system/kubeovn image
+ 	make -C packages/system/linstor image
+ 	make -C packages/system/linstor-gui image
++	make -C packages/system/kubeovn image
  	make -C packages/system/kubeovn-webhook image
  	make -C packages/system/kubeovn-plunger image
--	make -C packages/system/dashboard image
- 	make -C packages/system/metallb image
- 	make -C packages/system/kamaji image
- 	make -C packages/system/multus image
-@@ -34,7 +31,6 @@ build: build-deps
- 	make -C packages/system/objectstorage-controller image
- 	make -C packages/system/grafana-operator image
- 	make -C packages/core/testing image
--	make -C packages/core/talos image
- 	make -C packages/core/platform image
- 	make -C packages/core/installer image
- 	make manifests
+ 	make -C packages/system/dashboard image

--- a/patches/09-arm64-linstor-dashboard.patch
+++ b/patches/09-arm64-linstor-dashboard.patch
@@ -1,0 +1,56 @@
+diff --git a/packages/system/dashboard/Makefile b/packages/system/dashboard/Makefile
+index 44b6f27..8ae86bf 100644
+--- a/packages/system/dashboard/Makefile
++++ b/packages/system/dashboard/Makefile
+@@ -24,7 +24,7 @@ build-console:
+ 		--file .tmp-cozystack-ui/Containerfile \
+ 		--provenance false \
+ 		--builder=$(BUILDER) \
+-		--platform=linux/amd64 \
++		 \
+ 		--tag $(REGISTRY)/cozystack-ui:$(call settag,$(TAG)) \
+ 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-ui:latest \
+ 		--cache-to type=inline \
+@@ -45,7 +45,7 @@ image-token-proxy:
+ 	docker buildx build images/token-proxy \
+ 		--provenance false \
+ 		--builder=$(BUILDER) \
+-		--platform=linux/amd64 \
++		 \
+ 		--tag $(REGISTRY)/token-proxy:$(call settag,$(TAG)) \
+ 		--cache-from type=registry,ref=$(REGISTRY)/token-proxy:latest \
+ 		--cache-to type=inline \
+diff --git a/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff b/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff
+new file mode 100644
+index 0000000..c645ddd
+--- /dev/null
++++ b/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff
+@@ -0,0 +1,28 @@
++diff --git a/build.gradle b/build.gradle
++index e16793b..f34d70b 100644
++--- a/build.gradle
+++++ b/build.gradle
++@@ -580,7 +580,7 @@ tasks.register('unzipProtoc', Copy) {
++     dependsOn(downloadProtoc)
++ 
++-    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-x86_64.zip')
+++    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
++     def outputDir = file("tools/protoc-" + protobufVersion)
++ 
++     from zipTree(zipFile)
++@@ -594,7 +594,7 @@ tasks.register('downloadProtoc') {
++-    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-x86_64.zip')
+++    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
++     outputs.file protozip
++ 
++     doLast {
++         if (!protozip.exists()) {
++             mkdir "tools"
++             println "downloading protoc..."
++             new URL('https://github.com/google/protobuf/releases/download/v'
++-                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-x86_64.zip')
+++                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-aarch_64.zip')
++                     .withInputStream { i -> protozip.withOutputStream { it << i } }
++         }
++     }
++ }


### PR DESCRIPTION
## Description
This PR attempts to enable ARM64 builds for Linstor and Dashboard. 

## Key Changes
- **Linstor:** Patches `linstor-server` to use `aarch_64` protoc.
- **Dashboard:** Removes hardcoded amd64 platform.
- **Matrix:** Restores these packages to the build matrix.

Reverted from `main` to avoid blocking the release. Further troubleshooting required to fix CI failures.