### PR TITLE
docs: Systematize the Release Process (NUTMEG-13)

### DIFF
--- a/.gemini/skills/talos-release-manager/SKILL.md
+++ b/.gemini/skills/talos-release-manager/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: talos-release-manager
+description: Executes the strict CI-validated release process for Cozystack Talos assets. Use this skill when asked to merge to main, tag a release, or publish a new version of the Cozystack Talos project.
+---
+
+# Talos Release Manager
+
+## Overview
+
+This skill ensures that all releases of the Cozystack Talos assets are robust, properly cached, and fully validated by CI. It prevents race conditions and "vibes-based" releases by enforcing a strict waiting period for the `main` branch CI before tagging, and ensures the Release Provenance Rubric guarantees exactly 31+ OCI images are successfully shipped.
+
+## Release Process Workflow
+
+Follow these steps exactly when cutting a new release.
+
+### Step 1: Pre-Merge Validation
+Before merging a Pull Request into `main`:
+1. Verify the PR's CI pipeline has fully passed.
+2. If tests are still running, use `gh run list` and wait. Do not merge on failure or in progress.
+
+### Step 2: Merge to Main
+1. Execute the merge: `gh pr merge --merge --delete-branch` (or instruct the user to do so).
+2. Immediately switch your local environment to `main`: `git checkout main && git pull origin main`.
+
+### Step 3: Wait for Main CI (The Iron Rule)
+**CRITICAL: You MUST wait for the `main` branch CI (`build-talos-images.yml`) to pass completely before proceeding.** Tagging an unverified commit causes race conditions and corrupts the release cache.
+1. Run `gh run list --branch main --workflow build-talos-images.yml --limit 1`.
+2. Wait for the `STATUS` to be `completed` and the `CONCLUSION` to be `success`.
+3. If it fails, halt the release process and inform the user.
+
+### Step 4: Documentation (The Release Doc)
+1. Ensure you have the latest validated commit: `git pull origin main`.
+2. Create a new release document inside `docs/` named with an alphabetical code word (the next letter is N, e.g., `docs/NUTMEG-13-V1.4.0-1.13.2-2-RELEASE.md`). Previous letters were G-M (Galaxy, Hydrogen, Ion, Juniper, Kestrel, Lavender, Mint).
+3. The release doc should outline the contents of the release, emphasizing the board-specific images (CM4 vs. CM5).
+
+### Step 5: Tagging and Release
+1. Create the new release tag. Be sure to use the correct revision syntax if updating an existing Talos/Cozystack combination (e.g., `v1.4.0-1.13.2-2`).
+2. Run `git tag <tag-name>`.
+3. Run `git push origin <tag-name>`.
+
+### Step 6: Verify the Release Provenance Rubric
+1. The new tag will trigger the `release-talos-assets.yml` workflow.
+2. Monitor this workflow: `gh run list --branch <tag-name> --workflow release-talos-assets.yml --limit 1`.
+3. Wait for it to complete. The workflow includes the **Release Provenance Rubric** step (`tests/custom-image/05-release-provenance.sh`), which will mathematically guarantee the presence of all 31+ expected OCI images.
+4. Report the final success to the user.

--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -397,39 +397,40 @@ jobs:
           
           MATCHBOX_TAG="talos-${TALOS_VERSION}-cozy-${COZY_VER}"
           
-          NOTES=$(cat <<EOF
-## CozyStack ARM64 Talos Release ${FULL_TAG}
-**CozyStack upstream:** \`${COZY_VER}\`
-**Talos version:** \`${TALOS_VERSION}\`
-**Architecture:** ARM64 (Raspberry Pi CM4, CM5 and compatible boards)
+          cat > release_notes.md <<EOF
+          ## CozyStack ARM64 Talos Release ${FULL_TAG}
+          **CozyStack upstream:** \`${COZY_VER}\`
+          **Talos version:** \`${TALOS_VERSION}\`
+          **Architecture:** ARM64 (Raspberry Pi CM4, CM5 and compatible boards)
+          
+          ### OCI Images
+          #### Talos Installer (Upgrades)
+          - **Generic (CM4):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/talos:${TALOS_VERSION}\`
+          - **RPi5 (CM5):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/talos:${TALOS_VERSION}-rpi5\`
+          
+          #### Matchbox (Netboot)
+          - **Generic (CM4):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/matchbox:${MATCHBOX_TAG}\`
+          - **RPi5 (CM5):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/matchbox:${MATCHBOX_TAG}-rpi5\`
+          
+          #### Packages
+          - **Operator:** \`ghcr.io/urmanac/cozystack-assets/cozystack-operator:${COZY_VER}\`
+          - All system packages are tagged with \`${COZY_VER}\` and \`latest\`.
+          
+          ### Flashable Metal Images
+          - **CM4:** \`talos-metal-arm64-spin-hailort-${MATCHBOX_TAG}.raw.xz\`
+          - **CM5:** \`talos-metal-rpi5-arm64-spin-hailort-${MATCHBOX_TAG}.raw.xz\`
+          
+          ### Specialized RPi5 Netboot Assets
+          - **Kernel:** \`talos-kernel-rpi5-arm64-spin-hailort-${MATCHBOX_TAG}\`
+          - **Initramfs:** \`talos-initramfs-rpi5-arm64-spin-hailort-${MATCHBOX_TAG}.xz\`
+          
+          ---
+          *Verified by Release Provenance Rubric*
+          EOF
 
-### OCI Images
-#### Talos Installer (Upgrades)
-- **Generic (CM4):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/talos:${TALOS_VERSION}\`
-- **RPi5 (CM5):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/talos:${TALOS_VERSION}-rpi5\`
-
-#### Matchbox (Netboot)
-- **Generic (CM4):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/matchbox:${MATCHBOX_TAG}\`
-- **RPi5 (CM5):** \`ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/matchbox:${MATCHBOX_TAG}-rpi5\`
-
-#### Packages
-- **Operator:** \`ghcr.io/urmanac/cozystack-assets/cozystack-operator:${COZY_VER}\`
-- All system packages are tagged with \`${COZY_VER}\` and \`latest\`.
-
-### Flashable Metal Images
-- **CM4:** \`talos-metal-arm64-spin-hailort-${MATCHBOX_TAG}.raw.xz\`
-- **CM5:** \`talos-metal-rpi5-arm64-spin-hailort-${MATCHBOX_TAG}.raw.xz\`
-
-### Specialized RPi5 Netboot Assets
-- **Kernel:** \`talos-kernel-rpi5-arm64-spin-hailort-${MATCHBOX_TAG}\`
-- **Initramfs:** \`talos-initramfs-rpi5-arm64-spin-hailort-${MATCHBOX_TAG}.xz\`
-
----
-*Verified by Release Provenance Rubric*
-EOF
-)
+          sed -i 's/^          //' release_notes.md
 
           gh release create "$FULL_TAG" \
             --title "CozyStack ARM64 Talos ${FULL_TAG}" \
-            --notes "$NOTES" \
+            --notes-file release_notes.md \
             release-artifacts/*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,10 +22,10 @@ Before merging or tagging, always run the local validation suite:
 
 ## Release Process
 
+**MANDATORY:** Always activate and follow the `talos-release-manager` skill when merging to main or tagging a release.
+
 1.  Create a feature branch.
 2.  Implement changes and perform atomic commits.
 3.  Create a Pull Request.
-4.  Wait for all CI checks to pass.
-5.  Merge the PR.
-6.  Pull `main` and tag the release (e.g., `v1.4.0-1.13.2`).
-7.  Push the tag.
+4.  Activate the `talos-release-manager` skill (via `activate_skill` or equivalent CLI command) to orchestrate the merge and tagging process.
+5.  Strictly follow the skill's CI waiting periods and provenance verification rubric. Do NOT proceed to tagging without `main` CI passing.

--- a/docs/NUTMEG-13-V1.4.0-1.13.2-1-RELEASE.md
+++ b/docs/NUTMEG-13-V1.4.0-1.13.2-1-RELEASE.md
@@ -1,0 +1,38 @@
+# NUTMEG-13 (v1.4.0-1.13.2-1) Release Notes
+
+## Overview
+The **NUTMEG-13** release represents a major stabilization of the Cozystack Talos image build process, specifically addressing the requirements for multi-board architecture support (CM4 and CM5).
+
+We have eliminated "vibes-based" releases by instituting a strict CI provenance rubric. This ensures that a release tag mathematically guarantees the successful publication of all 31+ required OCI and metal images to our artifact registry.
+
+## Key Changes
+1. **Specialized RPi5 Support:**
+   - Introduced `rpi_5` firmware overlay to the `metal` and `installer` profiles.
+   - Introduced specialized `matchbox` images explicitly targeted for RPi5 netbooting, containing the `initramfs-rpi5` and `kernel-rpi5` profiles.
+2. **Release Provenance Rubric:**
+   - Every release is now validated by a strict rubric (`05-release-provenance.sh`), which confirms the successful build, tagging, and publication of all Cozystack and Talos images.
+3. **CI Orderly Release Pipeline:**
+   - Modified CI to allow revision tagging (e.g., `-1`).
+   - Defined strict rules via the `talos-release-manager` skill to ensure tags are only cut *after* the `main` branch cache is successfully seeded.
+
+## Artifacts
+
+### OCI Images
+**Talos Installer (Upgrades)**
+- Generic (CM4): `ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/talos:v1.13.2`
+- RPi5 (CM5): `ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/talos:v1.13.2-rpi5`
+
+**Matchbox (Netboot)**
+- Generic (CM4): `ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/matchbox:talos-v1.13.2-cozy-v1.4.0-1`
+- RPi5 (CM5): `ghcr.io/urmanac/cozystack-assets/talos/cozystack-spin-hailort/matchbox:talos-v1.13.2-cozy-v1.4.0-1-rpi5`
+
+**Cozystack Packages**
+- Operator: `ghcr.io/urmanac/cozystack-assets/cozystack-operator:v1.4.0-1.13.2-1`
+
+### Flashable Metal Images
+- CM4: `talos-metal-arm64-spin-hailort-talos-v1.13.2-cozy-v1.4.0-1.raw.xz`
+- CM5: `talos-metal-rpi5-arm64-spin-hailort-talos-v1.13.2-cozy-v1.4.0-1.raw.xz`
+
+### RPi5 Netboot Assets
+- Kernel: `talos-kernel-rpi5-arm64-spin-hailort-talos-v1.13.2-cozy-v1.4.0-1`
+- Initramfs: `talos-initramfs-rpi5-arm64-spin-hailort-talos-v1.13.2-cozy-v1.4.0-1.xz`


### PR DESCRIPTION
This PR introduces a 'System for Success' for our releases:

1. **`talos-release-manager` skill**: A workspace-level Gemini skill installed in `.gemini/skills/` that explicitly encodes the release rules (wait for `main` CI, verify provenance rubric).
2. **Updated `GEMINI.md`**: Mandates the use of this skill for all future merges and tags.
3. **Draft Release Doc**: Includes the new `NUTMEG-13-V1.4.0-1.13.2-1-RELEASE.md` document detailing the specialized RPi5 support and artifacts.

Please review the release document and skill workflow.