### PR TITLE
ci: Consolidate Patch Logic into shared hack script

### DIFF
--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -247,23 +247,7 @@ jobs:
       - name: Apply ARM64 conversion patches
         run: |
           cd cozystack-upstream
-          EXTENSION_VARIANT="${{ matrix.extension_variant }}"
-          git apply ../patches/04-arm64-default-platform.patch
-          if [ "$EXTENSION_VARIANT" = "spin-only" ]; then
-            git apply ../patches/03-arm64-spin-only.patch
-          elif [ "$EXTENSION_VARIANT" = "spin-hailort" ]; then
-            git apply ../patches/08-arm64-spin-hailort.patch
-          else
-            git apply ../patches/01-arm64-spin-tailscale.patch
-          fi
-          git apply ../patches/02-makefile-architecture-variables.patch
-          if [ "$EXTENSION_VARIANT" = "spin-hailort" ]; then
-            git apply ../patches/09-arm64-rpi5-spin-hailort.patch
-            git apply ../patches/10-arm64-rpi5-specialized-matchbox.patch
-          fi
-          chmod +x packages/core/talos/hack/gen-profiles.sh
-          chmod +x packages/core/talos/hack/gen-versions.sh
-
+          bash ../hack/patch-talos.sh "${{ matrix.extension_variant }}"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -197,20 +197,7 @@ jobs:
       - name: Apply ARM64 + variant patches
         run: |
           cd cozystack-upstream
-          EXTENSION_VARIANT="${{ matrix.extension_variant }}"
-          git apply ../patches/04-arm64-default-platform.patch
-          if [ "$EXTENSION_VARIANT" = "spin-only" ]; then
-            git apply ../patches/03-arm64-spin-only.patch
-          elif [ "$EXTENSION_VARIANT" = "spin-hailort" ]; then
-            git apply ../patches/08-arm64-spin-hailort.patch
-            git apply ../patches/09-arm64-rpi5-spin-hailort.patch
-            git apply ../patches/10-arm64-rpi5-specialized-matchbox.patch
-          else
-            git apply ../patches/01-arm64-spin-tailscale.patch
-          fi
-          git apply ../patches/02-makefile-architecture-variables.patch
-          chmod +x packages/core/talos/hack/gen-profiles.sh
-          chmod +x packages/core/talos/hack/gen-versions.sh
+          bash ../hack/patch-talos.sh "${{ matrix.extension_variant }}"
 
       - name: Build and push talos + matchbox
         run: |
@@ -265,13 +252,7 @@ jobs:
       - name: Apply spin-hailort ARM64 patches
         run: |
           cd cozystack-upstream
-          git apply ../patches/04-arm64-default-platform.patch
-          git apply ../patches/08-arm64-spin-hailort.patch
-          git apply ../patches/02-makefile-architecture-variables.patch
-          git apply ../patches/09-arm64-rpi5-spin-hailort.patch
-          git apply ../patches/10-arm64-rpi5-specialized-matchbox.patch
-          chmod +x packages/core/talos/hack/gen-profiles.sh
-          chmod +x packages/core/talos/hack/gen-versions.sh
+          bash ../hack/patch-talos.sh spin-hailort
 
       - name: Build Talos metal image
         run: |

--- a/hack/patch-talos.sh
+++ b/hack/patch-talos.sh
@@ -4,29 +4,32 @@ set -e
 VARIANT=$1
 [ -z "$VARIANT" ] && echo "Usage: $0 <variant>" && exit 1
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCH_DIR="$(cd "$SCRIPT_DIR/../patches" && pwd)"
+
 echo "🛠️ Applying patches for variant: $VARIANT"
 
 # Common ARM64 base patches
-git apply ../../patches/04-arm64-default-platform.patch
+git apply "$PATCH_DIR/04-arm64-default-platform.patch"
 
 # Variant-specific patches
 if [ "$VARIANT" = "spin-only" ]; then
-    git apply ../../patches/03-arm64-spin-only.patch
+    git apply "$PATCH_DIR/03-arm64-spin-only.patch"
 elif [ "$VARIANT" = "spin-hailort" ]; then
-    git apply ../../patches/08-arm64-spin-hailort.patch
+    git apply "$PATCH_DIR/08-arm64-spin-hailort.patch"
 elif [ "$VARIANT" = "spin-tailscale" ]; then
-    git apply ../../patches/01-arm64-spin-tailscale.patch
+    git apply "$PATCH_DIR/01-arm64-spin-tailscale.patch"
 fi
 
 # The Architecture Variables patch (02) MUST match the context of the previous patches.
 echo "🛠️ Applying architecture conversion patch 02"
-git apply ../../patches/02-makefile-architecture-variables.patch
+git apply "$PATCH_DIR/02-makefile-architecture-variables.patch"
 
 # RPi5 specialized patches MUST run after 02 because they use the arm64 strings 02 provides.
 if [ "$VARIANT" = "spin-hailort" ]; then
     echo "🛠️ Applying RPi5 specialized patches (09, 10)"
-    git apply ../../patches/09-arm64-rpi5-spin-hailort.patch
-    git apply ../../patches/10-arm64-rpi5-specialized-matchbox.patch
+    git apply "$PATCH_DIR/09-arm64-rpi5-spin-hailort.patch"
+    git apply "$PATCH_DIR/10-arm64-rpi5-specialized-matchbox.patch"
 fi
 
 chmod +x packages/core/talos/hack/gen-profiles.sh

--- a/hack/patch-talos.sh
+++ b/hack/patch-talos.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+VARIANT=$1
+[ -z "$VARIANT" ] && echo "Usage: $0 <variant>" && exit 1
+
+echo "🛠️ Applying patches for variant: $VARIANT"
+
+# Common ARM64 base patches
+git apply ../../patches/04-arm64-default-platform.patch
+
+# Variant-specific patches
+if [ "$VARIANT" = "spin-only" ]; then
+    git apply ../../patches/03-arm64-spin-only.patch
+elif [ "$VARIANT" = "spin-hailort" ]; then
+    git apply ../../patches/08-arm64-spin-hailort.patch
+elif [ "$VARIANT" = "spin-tailscale" ]; then
+    git apply ../../patches/01-arm64-spin-tailscale.patch
+fi
+
+# The Architecture Variables patch (02) MUST match the context of the previous patches.
+echo "🛠️ Applying architecture conversion patch 02"
+git apply ../../patches/02-makefile-architecture-variables.patch
+
+# RPi5 specialized patches MUST run after 02 because they use the arm64 strings 02 provides.
+if [ "$VARIANT" = "spin-hailort" ]; then
+    echo "🛠️ Applying RPi5 specialized patches (09, 10)"
+    git apply ../../patches/09-arm64-rpi5-spin-hailort.patch
+    git apply ../../patches/10-arm64-rpi5-specialized-matchbox.patch
+fi
+
+chmod +x packages/core/talos/hack/gen-profiles.sh
+chmod +x packages/core/talos/hack/gen-versions.sh
+
+echo "✅ All patches applied successfully for $VARIANT"


### PR DESCRIPTION
This PR addresses the critical divergence between the PR CI and the Release Tag workflow. 

Currently, the patch application sequence is duplicated across both workflows, leading to subtle out-of-sync failures (like the most recent v1.4.0-1.13.2-1 failure).

Changes:
- **`hack/patch-talos.sh`**: A new, version-controlled script that implements the strict `04 -> Variant -> 02 -> 09 -> 10` patch sequence.
- **Workflow Updates**: Replaced 30+ lines of duplicated YAML logic with a single call to the new script.

This ensures that if the PR CI passes, the Release Tag CI is mathematically guaranteed to apply patches in the same successful order.