### PR TITLE
feat: run build-sovereign-os on hosted runner for main branch push events

### DIFF
--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -206,7 +206,7 @@ jobs:
 
   # Stage 3a: Sovereign OS Factory
   build-sovereign-os:
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: ${{ github.ref == 'refs/heads/main' && 'ubuntu-24.04-arm' || fromJSON('["self-hosted", "linux", "arm64"]') }}
     permissions:
       packages: write
     outputs:


### PR DESCRIPTION
This PR updates the build-sovereign-os job in the integration workflow to run on a hosted GitHub runner (ubuntu-24.04-arm) instead of the self-hosted runner when executing on the main branch. Since the PR checks have already compiled and published the content-hashed sovereign images, the job on main only needs to check the registry and update the stable release tags. This removes the need to keep the self-hosted runner online after merging PRs to main.