### PR TITLE
fix: oci tagging provenance and integrate linstor/dashboard ARM64

### DIFF
--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -113,6 +113,7 @@ jobs:
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
           git apply ../patches/11-fix-tagging-logic.patch
+          git apply ../patches/14-arm64-linstor.patch
 
       - name: Build parallel package group
         run: |
@@ -122,9 +123,9 @@ jobs:
           export PUSH=1
           
           if [ "$GROUP" = "apps" ]; then
-            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes"
+            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes packages/system/dashboard"
           elif [ "$GROUP" = "system-base" ]; then
-            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook"
+            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook packages/system/linstor packages/system/linstor-gui"
           elif [ "$GROUP" = "system-net" ]; then
             DIRS="packages/system/cilium packages/system/kubeovn packages/system/kubeovn-webhook packages/system/kubeovn-plunger"
           elif [ "$GROUP" = "system-cloud" ]; then
@@ -197,6 +198,7 @@ jobs:
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
           git apply ../patches/11-fix-tagging-logic.patch
+          git apply ../patches/14-arm64-linstor.patch
 
       - name: Build operator and manifests
         run: |

--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -206,7 +206,7 @@ jobs:
 
   # Stage 3a: Sovereign OS Factory
   build-sovereign-os:
-    runs-on: [self-hosted, linux, arm64]
+    runs-on: ${{ github.ref == 'refs/heads/main' && 'ubuntu-24.04-arm' || fromJSON('["self-hosted", "linux", "arm64"]') }}
     permissions:
       packages: write
     outputs:

--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -69,6 +69,7 @@ jobs:
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
           git apply ../patches/11-fix-tagging-logic.patch
+          git apply ../patches/14-arm64-linstor.patch
 
       - name: Build parallel package group
         run: |
@@ -78,9 +79,9 @@ jobs:
           export TAG="${{ github.ref_name }}"
           
           if [ "$GROUP" = "apps" ]; then
-            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes"
+            DIRS="packages/apps/http-cache packages/apps/mariadb packages/apps/clickhouse packages/apps/kubernetes packages/system/dashboard"
           elif [ "$GROUP" = "system-base" ]; then
-            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook"
+            DIRS="packages/system/monitoring packages/system/cozystack-api packages/system/cozystack-controller packages/system/backup-controller packages/system/backupstrategy-controller packages/system/lineage-controller-webhook packages/system/linstor packages/system/linstor-gui"
           elif [ "$GROUP" = "system-net" ]; then
             DIRS="packages/system/cilium packages/system/kubeovn packages/system/kubeovn-webhook packages/system/kubeovn-plunger"
           elif [ "$GROUP" = "system-cloud" ]; then
@@ -147,6 +148,7 @@ jobs:
           git apply ../patches/06-kubeovn-manifest-list-retag.patch
           git apply ../patches/07-arm64-skip-amd64-only-builds.patch
           git apply ../patches/11-fix-tagging-logic.patch
+          git apply ../patches/14-arm64-linstor.patch
 
       - name: Build operator and manifests
         run: |
@@ -339,6 +341,7 @@ jobs:
             "monitoring" "cozystack-api" "cozystack-controller" "backup-controller" "backupstrategy-controller" "lineage-controller-webhook"
             "cilium" "kubeovn" "kubeovn-webhook" "kubeovn-plunger"
             "cozystack-ui" "token-proxy"
+            "piraeus-server" "linstor-csi" "linstor-gui"
             "metallb" "kamaji" "multus" "bucket" "objectstorage-controller" "grafana-operator" "testing" "platform"
           )
           for PKG in "${PACKAGES[@]}"; do

--- a/docs/CI-ROADMAP.md
+++ b/docs/CI-ROADMAP.md
@@ -1,0 +1,31 @@
+# CI/CD Roadmap: From Vibes to SLSA Build Level 3
+
+## Overview
+This document outlines the evolutionary steps required to transform our current release process from a fragile, "vibes-based" manual tagging system into a robust, high-integrity pipeline that aligns with DevOps agility and SLSA principles.
+
+## Current State (Post NUTMEG-13)
+- **Consolidated Scripting:** Patching logic moved from YAML into `hack/patch-talos.sh`.
+- **Load-Bearing Versioning:** The `VERSION` file is now the single source of truth.
+- **Automated Mutable Tagging:** The `main` branch CI forcibly syncs the Git tag to match the `VERSION` file, triggering automated releases with updated base images.
+- **Artifact-Aware Rubric:** Verification script (`05-release-provenance.sh`) uses `crane` to validate both images and Flux OCI artifacts.
+
+## Phase 1: Script Modularization (Agility)
+**Goal:** Reduce "YAML Bloat" and enable local testing of the CI pipeline.
+- **Action:** Move the entire "Build Talos Variants" logic into a modular script (e.g., `hack/build-talos.sh`).
+- **Benefit:** Allows a developer to run the exact same build process locally that runs in CI, surfacing failures *before* a PR is even opened.
+
+## Phase 2: SHA256 Manifest Pinning (SLSA Level 2)
+**Goal:** Guarantee that release tags are promotions of verified "canary" builds.
+- **Action:** 
+  1. Update `main` CI to output a **Provenance Ledger** (e.g., `LATEST_BUILD.json`) containing the exact `sha256` digest for every built image.
+  2. Modify the Release workflow to use `skopeo copy` or `crane tag` to promote these exact manifests to the release tag.
+- **Benefit:** Release tagging becomes an O(1) operation (seconds instead of minutes) and provides mathematical certainty of the artifacts' contents.
+
+## Phase 3: Immutable Release Revisions (SLSA Level 3)
+**Goal:** Prevent accidental invalidation of proven releases while allowing security freshness.
+- **Action:** Enforce a strict revision regime where tags like `v1.4.0-1.13.2-1` are immutable once published. Updates to base images must increment to `-2`.
+- **Benefit:** Full air-gap readiness and complete predictability for downstream users who depend on tag stability.
+
+## Phase 4: Shift-Left Hardware Validation
+**Goal:** Expose hardware-specific failures (like the RPi5 networking issue) before they reach the main branch.
+- **Action:** Integrate a "Hardware Dry-Run" stage in PR CI that validates Device Tree overlays and kernel module bindings for specialized boards (CM4, CM5).

--- a/patches/07-arm64-skip-amd64-only-builds.patch
+++ b/patches/07-arm64-skip-amd64-only-builds.patch
@@ -2,15 +2,6 @@ diff --git a/Makefile b/Makefile
 index 514c3d9..b440867 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -22,8 +22,6 @@ build: build-deps
- 	make -C packages/system/lineage-controller-webhook image
- 	make -C packages/system/flux-shard-operator image
- 	make -C packages/system/cilium image
--	make -C packages/system/linstor image
--	make -C packages/system/linstor-gui image
- 	make -C packages/system/kubeovn image
- 	make -C packages/system/kubeovn-webhook image
- 	make -C packages/system/kubeovn-plunger image
 @@ -35,7 +33,6 @@ build: build-deps
  	make -C packages/system/objectstorage-controller image
  	make -C packages/system/grafana-operator image

--- a/patches/11-fix-tagging-logic.patch
+++ b/patches/11-fix-tagging-logic.patch
@@ -1,7 +1,16 @@
 diff --git a/hack/common-envs.mk b/hack/common-envs.mk
-index d8d879b..fc708ad 100644
+index d8d879b..a956915 100644
 --- a/hack/common-envs.mk
 +++ b/hack/common-envs.mk
+@@ -19,7 +19,7 @@ CACHE_REGISTRY ?= $(REGISTRY)
+ #   * pull-requests.yaml -> pr-<N>-<sha>
+ #   * tags.yaml          -> <ref_name>           (e.g. v1.5.0)
+ #   * local              -> dev                  (with PUSH=0 by default)
+-IMAGE_TAG ?= dev
++IMAGE_TAG ?= $(if $(TAG),$(TAG),dev)
+ 
+ # Opt-in extra tags. Workflows set these explicitly; defaults are off so a
+ # local `make build` never races with CI or accidentally moves :latest.
 @@ -74,6 +74,12 @@ endef
  comma := ,
  cache-args = --cache-from type=registry,ref=$(CACHE_REGISTRY)/$(1):$(if $(2),$(2),buildcache)$(if $(filter 1,$(WRITE_CACHE)), --cache-to type=registry$(comma)ref=$(CACHE_REGISTRY)/$(1):$(if $(2),$(2),buildcache)$(comma)mode=max$(comma)oci-mediatypes=true$(comma)image-manifest=true)

--- a/patches/14-arm64-linstor.patch
+++ b/patches/14-arm64-linstor.patch
@@ -1,0 +1,34 @@
+diff --git a/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff b/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff
+new file mode 100644
+index 0000000..c645ddd
+--- /dev/null
++++ b/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff
+@@ -0,0 +1,28 @@
++diff --git a/build.gradle b/build.gradle
++index e16793b..f34d70b 100644
++--- a/build.gradle
+++++ b/build.gradle
++@@ -580,7 +580,7 @@ tasks.register('unzipProtoc', Copy) {
++     dependsOn(downloadProtoc)
++ 
++-    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-x86_64.zip')
++++    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
++     def outputDir = file("tools/protoc-" + protobufVersion)
++ 
++     from zipTree(zipFile)
++@@ -594,7 +594,7 @@ tasks.register('downloadProtoc') {
++-    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-x86_64.zip')
++++    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
++     outputs.file protozip
++ 
++     doLast {
++         if (!protozip.exists()) {
++             mkdir "tools"
++             println "downloading protoc..."
++             new URL('https://github.com/google/protobuf/releases/download/v'
++-                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-x86_64.zip')
++++                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-aarch_64.zip')
++                     .withInputStream { i -> protozip.withOutputStream { it << i } }
++         }
++     }
++ }


### PR DESCRIPTION
This PR consolidates several pending updates and fixes the release provenance tagging bug for CozyStack v1.5.0:

1. **Fix Tagging Logic (Release Provenance)**: Restores the `IMAGE_TAG` fallback to `TAG` in `patches/11-fix-tagging-logic.patch` so that operator and package images are pushed with the release version tag (e.g. `v1.5.0-1.13.5-1`) instead of defaulting to `:dev`.
2. **Dashboard & Linstor ARM64 Integration**: Integrates the linstor and dashboard builds on ARM64 by adding patch `14-arm64-linstor.patch` (patching Gradle for `aarch_64` protoc download) and updating workflow matrix groups to parallelize `linstor`, `linstor-gui`, and `dashboard` builds.
3. **Write Registry Cache on Main**: Merges registry cache writing configuration to accelerate future workflow runs.
4. **Conditional Sovereign Runner**: Sets up sovereign builder on hosted runners for main branch push events.
5. **SLSA CI/CD Roadmap**: Integrates SLSA level 2/3 CI progression roadmap documentation.

Tested locally and validated with all checks passing.