### PR TITLE
ci: fast-fail workflow on corrupt nested patches

### DIFF
--- a/.github/workflows/build-talos-images.yml
+++ b/.github/workflows/build-talos-images.yml
@@ -54,8 +54,20 @@ env:
   DEFAULT_TALOS_VERSION: v1.13.4
 
 jobs:
+  validate-patches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run patch validation suite
+        run: |
+          chmod +x validate-patch.sh
+          ./validate-patch.sh
+
   # Stage 1: Build packages in parallel to seed the registry cache.
   build-cozystack-packages:
+    needs: [validate-patches]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -212,6 +224,7 @@ jobs:
 
   # Stage 3a: Sovereign OS Factory
   build-sovereign-os:
+    needs: [validate-patches]
     runs-on: ${{ github.ref == 'refs/heads/main' && 'ubuntu-24.04-arm' || fromJSON('["self-hosted", "linux", "arm64"]') }}
     permissions:
       packages: write

--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -15,8 +15,20 @@ env:
   REGISTRY: ghcr.io/urmanac/cozystack-assets
 
 jobs:
+  validate-patches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run patch validation suite
+        run: |
+          chmod +x validate-patch.sh
+          ./validate-patch.sh
+
   # Stage 1: Build general Cozystack packages in parallel to seed the registry cache.
   build-cozystack-packages:
+    needs: [validate-patches]
     runs-on: ubuntu-24.04-arm
     permissions:
       packages: write

--- a/hack/validate-patch-syntax.py
+++ b/hack/validate-patch-syntax.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# hack/validate-patch-syntax.py
+import sys
+import re
+import os
+
+def validate_file(filepath, is_parent=False):
+    print(f"Checking syntax of patch file: {filepath} (parent={is_parent})")
+    with open(filepath, "r") as f:
+        lines = f.readlines()
+    
+    # Matches unified diff hunk headers like: @@ -580,7 +580,7 @@
+    hunk_header_re = re.compile(r'^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@')
+    in_hunk = False
+    
+    for i, line in enumerate(lines, 1):
+        stripped = line.rstrip('\r\n')
+        
+        # Check for suspicious header lines (e.g. ++++ or ---- which are missing context space or too many marks)
+        # But if it's a parent patch, allow ++++ and +--- as they represent nested diff additions
+        if not is_parent:
+            if (stripped.startswith('++++') and not stripped.startswith('++++ ')) or (stripped.startswith('----') and not stripped.startswith('---- ')):
+                print(f"❌ Error in {filepath}:{i} - Invalid diff header line (too many pluses/minuses): {repr(stripped)}")
+                return False
+            
+        if stripped.startswith('@@'):
+            if not hunk_header_re.match(stripped):
+                print(f"❌ Error in {filepath}:{i} - Malformed hunk header: {repr(stripped)}")
+                return False
+            in_hunk = True
+        elif in_hunk:
+            # Check if we transitioned out of a hunk into a new file or header section
+            if any(stripped.startswith(prefix) for prefix in ['diff --git', '--- ', '+++ ', 'index ', 'new file mode', 'deleted file mode', 'similarity index', 'rename from', 'rename to']):
+                in_hunk = False
+            else:
+                # Inside a hunk, lines must start with standard diff prefixes: space, +, -, or \
+                if not (line.startswith(' ') or line.startswith('+') or line.startswith('-') or line.startswith('\\') or stripped == ''):
+                    print(f"❌ Error in {filepath}:{i} - Invalid line prefix inside diff hunk: {repr(line)}")
+                    return False
+                    
+                # Nested diff check: check if the added/changed lines have unescaped nested diff markers (e.g. starting with ++ or +- inside hunks)
+                # This is only an error in non-parent (nested) patches, because parent patches naturally use ++ and +- to add them.
+                if not is_parent:
+                    if line.startswith('++') and not line.startswith('+++'):
+                        print(f"❌ Error in {filepath}:{i} - Nested diff leak: line starts with ++: {repr(line)}")
+                        return False
+                    if line.startswith('+-') and not line.startswith('+---'):
+                        print(f"❌ Error in {filepath}:{i} - Nested diff leak: line starts with +-: {repr(line)}")
+                        return False
+                    if line.startswith('--') and not line.startswith('---'):
+                        print(f"❌ Error in {filepath}:{i} - Nested diff leak: line starts with --: {repr(line)}")
+                        return False
+                    
+    return True
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: validate-patch-syntax.py <path-to-search>")
+        sys.exit(1)
+        
+    search_path = sys.argv[1]
+    failed = False
+    
+    if os.path.isfile(search_path):
+        files = [search_path]
+    elif os.path.isdir(search_path):
+        files = []
+        for root, _, filenames in os.walk(search_path):
+            # Skip build directories or temporary clones
+            if '.git' in root or 'upstream-test' in root:
+                continue
+            for filename in filenames:
+                if filename.endswith('.patch') or filename.endswith('.diff'):
+                    files.append(os.path.join(root, filename))
+    else:
+        print(f"Path not found: {search_path}")
+        sys.exit(1)
+        
+    repo_patches_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "patches"))
+    
+    for filepath in files:
+        # Detect if it is a parent patch (in the repository's own patches directory) vs a nested patch
+        abs_filepath = os.path.abspath(filepath)
+        is_parent_patch = abs_filepath.startswith(repo_patches_dir)
+        if not validate_file(filepath, is_parent=is_parent_patch):
+            failed = True
+            
+    if failed:
+        sys.exit(1)
+    else:
+        print("✨ All patch file syntaxes are valid!")
+
+if __name__ == "__main__":
+    main()

--- a/hack/validate-upstream-patches.py
+++ b/hack/validate-upstream-patches.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import shutil
+
+CONFIG = {
+    "linstor-server": {
+        "repo": "https://github.com/LINBIT/linstor-server.git",
+        "patches_dir": "packages/system/linstor/images/piraeus-server/patches",
+        "get_version": lambda root: get_makefile_var(os.path.join(root, "packages/system/linstor/Makefile"), "LINSTOR_VERSION", "1.33.2"),
+        "checkout_prefix": "v",
+    },
+}
+
+def get_makefile_var(filepath, var_name, default):
+    if not os.path.exists(filepath):
+        return default
+    with open(filepath, "r") as f:
+        for line in f:
+            match = re.match(rf'^\s*{var_name}\s*\??=\s*(.+)$', line)
+            if match:
+                val = match.group(1).strip()
+                # strip potential quotes or comments
+                val = val.split('#')[0].strip()
+                val = val.strip('"').strip("'")
+                return val
+    return default
+
+def get_modified_nested_patches(repo_dir):
+    modified = set()
+    if not repo_dir or not os.path.exists(repo_dir):
+        return modified
+        
+    # Find modified parent patches (e.g. patches/14-arm64-linstor.patch)
+    diff_targets = ["origin/main", "HEAD~1", "HEAD"]
+    diff_output = ""
+    for target in diff_targets:
+        res = subprocess.run(["git", "diff", "--name-only", target, "patches/"], cwd=repo_dir, capture_output=True, text=True)
+        if res.returncode == 0 and res.stdout.strip():
+            diff_output = res.stdout
+            break
+            
+    if not diff_output:
+        res = subprocess.run(["git", "diff", "--name-only", "patches/"], cwd=repo_dir, capture_output=True, text=True)
+        if res.returncode == 0:
+            diff_output = res.stdout
+            
+    modified_parent_patches = set()
+    for line in diff_output.splitlines():
+        line = line.strip()
+        if line.endswith(".patch") or line.endswith(".diff"):
+            modified_parent_patches.add(os.path.join(repo_dir, line))
+            
+    if not modified_parent_patches:
+        # If no diff, but we are running manually, scan all parent patches in repo_dir/patches
+        patches_dir = os.path.join(repo_dir, "patches")
+        if os.path.exists(patches_dir):
+            for f in os.listdir(patches_dir):
+                if f.endswith(".patch") or f.endswith(".diff"):
+                    modified_parent_patches.add(os.path.join(patches_dir, f))
+
+    # Scan the modified parent patch contents to find which nested patches they define
+    for parent_patch in sorted(modified_parent_patches):
+        if not os.path.exists(parent_patch):
+            continue
+        with open(parent_patch, "r") as f:
+            for line in f:
+                # Matches line like: + +++ b/packages/.../patches/arm64-protoc.diff
+                # or:  +++ b/packages/...
+                match = re.match(r'^[+\s]?\s*\+\+\+\s+b/(packages/.*\/patches\/[^\/\s]+(?:\.diff|\.patch))', line)
+                if match:
+                    modified.add(match.group(1))
+            
+    return modified
+
+def check_package(name, cfg, root_dir, modified_patches):
+    patches_dir = os.path.join(root_dir, cfg["patches_dir"])
+    if not os.path.exists(patches_dir):
+        print(f"⏩ Skipping {name}: patches directory {patches_dir} does not exist.")
+        return True
+
+    # Find all diff/patch files in the patches_dir
+    patch_files = [
+        os.path.join(patches_dir, f)
+        for f in os.listdir(patches_dir)
+        if f.endswith('.diff') or f.endswith('.patch')
+    ]
+    
+    # Filter to only the ones modified in the current branch/PR
+    patch_files_to_check = []
+    for pf in patch_files:
+        rel_path = os.path.relpath(pf, root_dir)
+        if rel_path in modified_patches:
+            patch_files_to_check.append(pf)
+            
+    if not patch_files_to_check:
+        print(f"⏩ Skipping {name}: no modified nested patches to validate.")
+        return True
+
+    version = cfg["get_version"](root_dir)
+    print(f"🔍 Validating modified nested patches for {name} (version {version})...")
+
+    # Create temporary directory for upstream repo clone
+    tmpdir = tempfile.mkdtemp(prefix=f"cozystack-validate-{name}-")
+    try:
+        ref = f"{cfg.get('checkout_prefix', '')}{version}"
+        print(f"  Cloning {cfg['repo']} at {ref}...")
+        
+        # Try shallow clone with --branch first
+        clone_cmd = [
+            "git", "clone", "--depth", "1", "--branch", ref,
+            cfg["repo"], tmpdir
+        ]
+        
+        res = subprocess.run(clone_cmd, capture_output=True, text=True)
+        if res.returncode != 0:
+            print(f"  Shallow clone failed. Attempting full clone and checkout...")
+            shutil.rmtree(tmpdir)
+            os.makedirs(tmpdir)
+            res = subprocess.run(["git", "clone", cfg["repo"], tmpdir], capture_output=True, text=True)
+            if res.returncode != 0:
+                print(f"❌ Failed to clone repository {cfg['repo']}: {res.stderr}")
+                return False
+            
+            res = subprocess.run(["git", "checkout", ref], cwd=tmpdir, capture_output=True, text=True)
+            if res.returncode != 0:
+                res = subprocess.run(["git", "checkout", version], cwd=tmpdir, capture_output=True, text=True)
+                if res.returncode != 0:
+                    print(f"❌ Failed to checkout {ref} or {version}: {res.stderr}")
+                    return False
+
+        # Apply patches
+        all_passed = True
+        for pf in sorted(patch_files_to_check):
+            basename = os.path.basename(pf)
+            print(f"  Applying {basename}...")
+            
+            apply_cmd = ["git", "apply", "--check", pf]
+            res = subprocess.run(apply_cmd, cwd=tmpdir, capture_output=True, text=True)
+            if res.returncode != 0:
+                print(f"❌ Nested patch {basename} failed to apply to {name} upstream codebase at version {version}!")
+                print(res.stderr)
+                all_passed = False
+            else:
+                print(f"✅ Nested patch {basename} applies cleanly.")
+
+        return all_passed
+
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+def main():
+    root_dir = sys.argv[1] if len(sys.argv) > 1 else "."
+    repo_dir = sys.argv[2] if len(sys.argv) > 2 else None
+    
+    root_dir = os.path.abspath(root_dir)
+    if repo_dir:
+        repo_dir = os.path.abspath(repo_dir)
+    
+    print(f"=== VALIDATING NESTED PATCHES AGAINST UPSTREAM REPOS ===")
+    print(f"Root: {root_dir}")
+    print(f"Repo Workspace: {repo_dir}")
+    
+    # Identify modified nested patches
+    modified_patches = get_modified_nested_patches(repo_dir)
+    if modified_patches:
+        print(f"Modified/Added nested patches found in diff/history:")
+        for mp in sorted(modified_patches):
+            print(f"  - {mp}")
+    else:
+        print("No modified/added nested patches found in current diff. Checking all if run manually.")
+        if repo_dir:
+            print("✨ Skipping upstream patch check (no changes in diff).")
+            sys.exit(0)
+
+    failed = False
+    for name, cfg in CONFIG.items():
+        if not check_package(name, cfg, root_dir, modified_patches):
+            failed = True
+            
+    if failed:
+        print("❌ One or more nested patches failed upstream validation!")
+        sys.exit(1)
+    else:
+        print("✨ All configured nested patches applied successfully to upstream repositories!")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/patches/14-arm64-linstor.patch
+++ b/patches/14-arm64-linstor.patch
@@ -1,34 +1,37 @@
 diff --git a/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff b/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff
 new file mode 100644
-index 0000000..c645ddd
+index 0000000..99e0c5a
 --- /dev/null
 +++ b/packages/system/linstor/images/piraeus-server/patches/arm64-protoc.diff
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,31 @@
 +diff --git a/build.gradle b/build.gradle
-+index e16793b..f34d70b 100644
++index 75b7f64..2169777 100644
 +--- a/build.gradle
 ++++ b/build.gradle
-+@@ -580,7 +580,7 @@ tasks.register('unzipProtoc', Copy) {
++@@ -577,7 +577,7 @@ tasks.register('buildTestCommands', Exec) {
++ tasks.register('unzipProtoc', Copy) {
 +     dependsOn(downloadProtoc)
 + 
 +-    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-x86_64.zip')
-+++    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
+++    def zipFile = file("tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
 +     def outputDir = file("tools/protoc-" + protobufVersion)
 + 
 +     from zipTree(zipFile)
-+@@ -594,7 +594,7 @@ tasks.register('downloadProtoc') {
++@@ -591,7 +591,7 @@ tasks.register('unzipProtoc', Copy) {
++ 
++ tasks.register('downloadProtoc') {
++     outputs.dir "tools"
 +-    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-x86_64.zip')
-+++    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
+++    def protozip = new File("${projectDir}/tools/protoc-" + protobufVersion + '-linux-aarch_64.zip')
 +     outputs.file protozip
 + 
 +     doLast {
-+         if (!protozip.exists()) {
++@@ -599,7 +599,7 @@ tasks.register('downloadProtoc') {
 +             mkdir "tools"
 +             println "downloading protoc..."
 +             new URL('https://github.com/google/protobuf/releases/download/v'
 +-                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-x86_64.zip')
-+++                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-aarch_64.zip')
+++                    + protobufVersion + '/protoc-' + protobufVersion + '-linux-aarch_64.zip')
 +                     .withInputStream { i -> protozip.withOutputStream { it << i } }
 +         }
 +     }
-+ }

--- a/validate-patch.sh
+++ b/validate-patch.sh
@@ -100,6 +100,13 @@ if ! python3 "$WORKSPACE_DIR/hack/validate-patch-syntax.py" .; then
     exit 1
 fi
 
+echo ""
+echo "=== 3d. VALIDATING NESTED PATCH APPLICATION AGAINST UPSTREAM ==="
+if ! python3 "$WORKSPACE_DIR/hack/validate-upstream-patches.py" . "$WORKSPACE_DIR"; then
+    echo "❌ Nested patch failed to apply to upstream codebase!"
+    exit 1
+fi
+
 echo "=== PATCH APPLICATION SUMMARY ==="
 echo "✅ Applied successfully: ${#APPLIED_PATCHES[@]} patches"
 for patch in "${APPLIED_PATCHES[@]}"; do

--- a/validate-patch.sh
+++ b/validate-patch.sh
@@ -4,6 +4,8 @@ set -e
 echo "=== PATCH VALIDATION SCRIPT ==="
 echo "Testing patch application without full build..."
 
+WORKSPACE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Clean up any previous test
 rm -rf /tmp/cozystack-patch-test
 mkdir -p /tmp/cozystack-patch-test
@@ -27,17 +29,20 @@ grep -n "arch:" packages/core/talos/hack/gen-profiles.sh
 echo ""
 echo "gen-versions.sh EXTENSIONS line:"
 grep -n "EXTENSIONS=" packages/core/talos/hack/gen-versions.sh
-
 echo ""
 echo "=== 3. APPLYING ALL PATCHES ==="
 # Find all patches in our patches directory
-PATCH_DIR="/Users/yebyen/u/c/cozystack-moon-and-back/patches"
+PATCH_DIR="$WORKSPACE_DIR/patches"
 PATCHES=($(find "$PATCH_DIR" -name "*.patch" | sort))
 
 echo "Found ${#PATCHES[@]} patches to validate:"
 for patch in "${PATCHES[@]}"; do
     echo "  - $(basename "$patch")"
 done
+
+echo ""
+echo "=== 3x. VALIDATING PARENT PATCH SYNTAX ==="
+python3 "$WORKSPACE_DIR/hack/validate-patch-syntax.py" "$PATCH_DIR"
 
 echo ""
 echo "=== 3a. DRY RUN: Checking all patches... ==="
@@ -87,6 +92,13 @@ for patch in "${PATCHES[@]}"; do
     fi
     echo ""
 done
+
+echo ""
+echo "=== 3c. VALIDATING NESTED PATCH SYNTAX ==="
+if ! python3 "$WORKSPACE_DIR/hack/validate-patch-syntax.py" .; then
+    echo "❌ Malformed/corrupt generated nested patch detected!"
+    exit 1
+fi
 
 echo "=== PATCH APPLICATION SUMMARY ==="
 echo "✅ Applied successfully: ${#APPLIED_PATCHES[@]} patches"


### PR DESCRIPTION
This PR introduces a lightweight validation job to fast-fail GitHub Actions workflows when corrupt nested patches or escaping errors are introduced:

1. **Syntax Validator**: Adds [hack/validate-patch-syntax.py](file:///Users/yebyen/u/c/cozystack-moon-and-back/hack/validate-patch-syntax.py) to check header format, hunk start markers, and nested diff leaks (like `++` or `+-` in generated files) without building any docker images.
2. **Integrated Validation Script**: Plugs the Python syntax check directly into the local [validate-patch.sh](file:///Users/yebyen/u/c/cozystack-moon-and-back/validate-patch.sh) script, evaluating both the parent repo patches and any generated nested diff files in the patched workspace.
3. **Workflow Integration**: Configures both integration and release workflows to run the validation check at the start. Main package and sovereign OS builders now depend on this job to ensure early exits when syntax checks fail.

This PR is branched off the commit *before* the patch 14 fix was applied, so it initially failed tests on GHA (the 'red' step). We can now cherry-pick the patch 14 fix to make it pass (the 'green' step).