### PR TITLE
fix(ci): define tag and publish variables in release workflow

### DIFF
--- a/.github/workflows/release-talos-assets.yml
+++ b/.github/workflows/release-talos-assets.yml
@@ -13,6 +13,9 @@ on:
 
 env:
   REGISTRY: ghcr.io/urmanac/cozystack-assets
+  TAG: ${{ github.ref_name }}
+  PUBLISH_VERSIONED: '1'
+  PUBLISH_FLOATING: '1'
 
 jobs:
   validate-patches:


### PR DESCRIPTION
This PR fixes the tagging logic in the release workflow by defining TAG, PUBLISH_VERSIONED, and PUBLISH_FLOATING at the workflow level to ensure release images are tagged correctly (e.g. v1.13.5 and v1.5.0-1.13.5-1 instead of defaulting to dev).